### PR TITLE
Add ESPN disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # ESPN OpenAPI Specs
 
+> **⚠️ DISCLAIMER**
+> 
+> This project is **NOT** affiliated with, endorsed by, or associated with ESPN in any way. This is an independent, community-driven project.
+> 
+> **IMPORTANT**: When using these API specifications, you must:
+> - Comply with ESPN's Terms of Service
+> - Respect rate limits and usage policies
+> - Use the APIs responsibly and ethically
+> - Be aware that ESPN may change or restrict access to these APIs at any time
+
 The goal of this project is to provide a collection of OpenAPI specs for the various ESPN APIs with full type definitions for the responses. This will allow developers to generate clients in any language to interact with the API, generally to fetch real-time or historical sports data.
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # ESPN OpenAPI Specs
-
-> **⚠️ DISCLAIMER**
-> 
-> This project is **NOT** affiliated with, endorsed by, or associated with ESPN in any way. This is an independent, community-driven project.
+ 
+> This project is **NOT** affiliated with, endorsed by, or associated with ESPN in any way.
 > 
 > **IMPORTANT**: When using these API specifications, you must:
 > - Comply with ESPN's Terms of Service


### PR DESCRIPTION
## Summary
- Adds a clear disclaimer to the README to clarify that the project is not affiliated with ESPN
- Provides important usage guidelines for users of the API specifications

## Changes

### Documentation
- **README.md**: Inserted a prominent disclaimer section at the top of the README
  - States the project is independent and not endorsed by ESPN
  - Lists key points for responsible API usage including compliance with ESPN's Terms of Service, respecting rate limits, and awareness of potential API changes

## Test plan
- [x] Verified the disclaimer is clearly visible at the top of the README
- [x] Confirmed the formatting uses blockquote and bold text for emphasis
- [x] Checked that usage guidelines are concise and informative

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/419e2ed4-c5e3-4820-843b-0dc40d324f88