### PR TITLE
consolidate to agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cloud-specific instructions
+
+### Overview
+
+Python-only repo of ESPN OpenAPI specs and auto-generated API clients. No local services, databases, or Docker required. All tests hit live ESPN APIs over the network.
+
+### Dependencies
+
+- **Package manager:** `uv` (installed at `~/.local/bin/uv`; ensure `$HOME/.local/bin` is on `PATH`)
+- **Python:** ≥3.9 (system Python 3.12 works)
+- **Install deps:** `uv sync --all-extras` (installs both runtime and dev dependencies from `uv.lock`)
+- **Extra pytest plugins:** `pytest-xdist` and `pytest-retry` are required by `pytest.ini` but not listed in `pyproject.toml`. Install them with: `uv pip install pytest-xdist pytest-retry`
+
+### Running tests
+
+Tests call live ESPN APIs and require network access. See `pytest.ini` for config.
+
+- **All tests:** `uv run pytest`
+- **Single file:** `uv run pytest tests/test_scoreboard.py -v`
+- **Via Makefile:** `make run-test TEST_FILE=tests/test_scoreboard.py`
+
+Tests run in parallel (`-n auto` via pytest-xdist) with retries (`--retries 2`).
+
+### Linting
+
+- `uv run ruff check .`
+- `uv run black --check .`
+- `uv run isort --check .`
+
+### Code generation
+
+Regenerate Python clients from OpenAPI specs: `make openapi` (requires `openapi-python-client` which is included in dev deps).


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` with cloud-specific development instructions for future cloud agents.

### Changes
- Created `AGENTS.md` with sections covering:
  - Project overview (Python ESPN OpenAPI client library)
  - Dependency installation (`uv sync --all-extras` + pytest plugins)
  - Test execution commands (live ESPN API tests)
  - Linting commands (`ruff`, `black`, `isort`)
  - Code generation via Makefile

### Environment Setup Verified
- Installed `uv` package manager
- Installed all dependencies via `uv sync --all-extras`
- Installed missing pytest plugins (`pytest-xdist`, `pytest-retry`)
- Ran linters successfully (`ruff`, `black`, `isort`)
- Ran 26 tests across 4 test files — all passing
- Demonstrated live ESPN API usage (fetched today's NBA scoreboard with 10 games)

---
<p><a href="https://cursor.com/agents?id=bc-3965a6b7-6507-4bcf-bcc9-5b7fe7999445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3965a6b7-6507-4bcf-bcc9-5b7fe7999445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

