### PR TITLE
[gambit] document tournament challenge api

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ This project includes clients for the following ESPN APIs, located in the `model
     -   Allows interaction with ESPN's fantasy sports platform. You can manage leagues, teams, players, and scores.
     -   Client module: `models.fantasy_api.espn_fantasy_api_client`
 
+-   **`models/gambit_api/` (ESPN Gambit API)**:
+    -   Covers ESPN pick'em and bracket challenges, including Tournament Challenge.
+    -   Client module: `models.gambit_api.espn_gambit_api_client`
+
 -   **`models/site_api/` (ESPN Site API)**:
     -   Likely interacts with the main ESPN website's public-facing API. This could provide news, articles, standings, and team information.
     -   Client module: `models.site_api.espn_nfl_api_client` (Example for NFL)
@@ -75,6 +79,10 @@ This project includes clients for the following ESPN APIs, located in the `model
     -   Client module: `models.sports_core_api.espn_sports_core_api_client`
 
 Each client is generated from an OpenAPI specification and provides typed data models for API responses. You can explore the respective subdirectories for specific API operations and models.
+
+## Tournament Challenge
+
+Tournament Challenge rides on the Gambit API. The verified men's and women's challenge aliases, canonical keys, challenge IDs, and working endpoint patterns are documented in `TOURNAMENT_CHALLENGE.md`.
 
 
 ## License

--- a/TOURNAMENT_CHALLENGE.md
+++ b/TOURNAMENT_CHALLENGE.md
@@ -1,0 +1,74 @@
+# ESPN Tournament Challenge API Notes
+
+This repo did not previously map Tournament Challenge explicitly. The live API is part of the existing ESPN Gambit surface at `https://gambit-api.fantasy.espn.com`, but the Tournament Challenge aliases, season keys, and `/apis/v1/propositions` response shape were not documented here.
+
+## Verified challenge keys
+
+These values were verified against the live site and Gambit API on 2026-03-17.
+
+| Product | Fantasy page alias | Gambit alias | Canonical challenge key | Challenge ID | Game ID | League mapping |
+| --- | --- | --- | --- | --- | --- | --- |
+| Men's Tournament Challenge | `https://fantasy.espn.com/games/tcmen` | `tcmen` | `tournament-challenge-bracket-2026` | `277` | `72` | `mens-college-basketball` |
+| Women's Tournament Challenge | `https://fantasy.espn.com/games/tcwomen` | `tcwomen` | `tournament-challenge-bracket-women-2026` | `278` | `73` | `womens-college-basketball` |
+
+The short aliases and the season-specific keys both work on the Gambit endpoints. The response `key` normalizes to the season-specific canonical key.
+
+## Working endpoints
+
+### Challenge details
+
+Use the alias or canonical key:
+
+- `GET https://gambit-api.fantasy.espn.com/apis/v1/challenges/tcmen?view=details`
+- `GET https://gambit-api.fantasy.espn.com/apis/v1/challenges/tcwomen?view=details`
+- `GET https://gambit-api.fantasy.espn.com/apis/v1/challenges/tournament-challenge-bracket-2026?view=details`
+- `GET https://gambit-api.fantasy.espn.com/apis/v1/challenges/tournament-challenge-bracket-women-2026?view=details`
+
+This response contains the canonical `key`, numeric `id`, `gameType`, `mappings`, `featuredGroupIds`, scoring periods, and an embedded `propositions` list.
+
+## Leaderboard
+
+- `GET https://gambit-api.fantasy.espn.com/apis/v1/challenges/tcmen/leaderboard?view=ranks&limit=10`
+- `GET https://gambit-api.fantasy.espn.com/apis/v1/challenges/tcwomen/leaderboard?view=ranks&limit=10`
+
+The leaderboard response uses the numeric `challengeId` and returns `entries` objects with nested `member`, `name`, `score`, and `picks` data.
+
+## Group lookup
+
+Use a `groupId` from `featuredGroupIds` in the challenge details response or from a group URL on the fantasy site:
+
+- `GET https://gambit-api.fantasy.espn.com/apis/v1/challenges/tcmen/groups/{groupId}`
+
+Example verified group:
+
+- `GET https://gambit-api.fantasy.espn.com/apis/v1/challenges/tcmen/groups/6e682872-7e5f-3aa2-84bf-003cb6a630ae`
+
+## Propositions
+
+Use the numeric `challengeId` from challenge details:
+
+- `GET https://gambit-api.fantasy.espn.com/apis/v1/propositions?challengeId=277`
+- `GET https://gambit-api.fantasy.espn.com/apis/v1/propositions?challengeId=278`
+
+Important: this endpoint returns a top-level JSON array, not an object wrapper.
+
+For Tournament Challenge, each proposition maps back to ESPN basketball data through `mappings` such as:
+
+- `LEAGUE`
+- `COMPETITION_ID`
+- `EVENT_ID`
+- `COMPETITOR_ID`
+- `URL_DESKTOP`
+
+The live propositions also include `possibleOutcomes`, which is the bracket-team choice set for each matchup.
+
+## Discovery workflow
+
+If the season-specific keys change in a future year, the fastest way to rediscover them is:
+
+1. Load the fantasy pages for `tcmen` or `tcwomen`.
+2. Inspect the server-rendered HTML for `challengeKey`, `challengeId`, and `gameId`.
+3. Call `GET /apis/v1/challenges/{challengeName}?view=details`.
+4. Use the returned numeric `id` with `GET /apis/v1/propositions?challengeId=...`.
+
+The page HTML currently embeds all three values, so the browser page is enough to recover the Gambit mapping without reverse-engineering the JS bundles.

--- a/models/gambit_api/espn_gambit_api_client/api/default/__init__.py
+++ b/models/gambit_api/espn_gambit_api_client/api/default/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/models/gambit_api/espn_gambit_api_client/api/default/get_challenge_details.py
+++ b/models/gambit_api/espn_gambit_api_client/api/default/get_challenge_details.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -16,8 +16,8 @@ def _get_kwargs(
     *,
     scoring_period_id: Union[Unset, int] = UNSET,
     view: Union[Unset, GetChallengeDetailsView] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["scoringPeriodId"] = scoring_period_id
 
@@ -29,7 +29,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": f"/apis/v1/challenges/{challenge_name}",
         "params": params,
@@ -75,11 +75,14 @@ def sync_detailed(
 ) -> Response[Union[ChallengeResponse, ErrorResponse]]:
     """Get Challenge Details
 
-     Retrieve detailed information about a specific Pick'em challenge.
-    Common challenge names include 'nfl-pigskin-pickem-2025' for NFL Pick'em.
+     Retrieve detailed information about a specific Pick'em or bracket challenge.
+    Verified Tournament Challenge aliases include 'tcmen' and 'tcwomen'.
+    The live API also accepts season-specific keys such as
+    'tournament-challenge-bracket-2026' and
+    'tournament-challenge-bracket-women-2026'.
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         scoring_period_id (Union[Unset, int]):  Example: 1.
         view (Union[Unset, GetChallengeDetailsView]):  Example: picks.
 
@@ -113,11 +116,14 @@ def sync(
 ) -> Optional[Union[ChallengeResponse, ErrorResponse]]:
     """Get Challenge Details
 
-     Retrieve detailed information about a specific Pick'em challenge.
-    Common challenge names include 'nfl-pigskin-pickem-2025' for NFL Pick'em.
+     Retrieve detailed information about a specific Pick'em or bracket challenge.
+    Verified Tournament Challenge aliases include 'tcmen' and 'tcwomen'.
+    The live API also accepts season-specific keys such as
+    'tournament-challenge-bracket-2026' and
+    'tournament-challenge-bracket-women-2026'.
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         scoring_period_id (Union[Unset, int]):  Example: 1.
         view (Union[Unset, GetChallengeDetailsView]):  Example: picks.
 
@@ -146,11 +152,14 @@ async def asyncio_detailed(
 ) -> Response[Union[ChallengeResponse, ErrorResponse]]:
     """Get Challenge Details
 
-     Retrieve detailed information about a specific Pick'em challenge.
-    Common challenge names include 'nfl-pigskin-pickem-2025' for NFL Pick'em.
+     Retrieve detailed information about a specific Pick'em or bracket challenge.
+    Verified Tournament Challenge aliases include 'tcmen' and 'tcwomen'.
+    The live API also accepts season-specific keys such as
+    'tournament-challenge-bracket-2026' and
+    'tournament-challenge-bracket-women-2026'.
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         scoring_period_id (Union[Unset, int]):  Example: 1.
         view (Union[Unset, GetChallengeDetailsView]):  Example: picks.
 
@@ -182,11 +191,14 @@ async def asyncio(
 ) -> Optional[Union[ChallengeResponse, ErrorResponse]]:
     """Get Challenge Details
 
-     Retrieve detailed information about a specific Pick'em challenge.
-    Common challenge names include 'nfl-pigskin-pickem-2025' for NFL Pick'em.
+     Retrieve detailed information about a specific Pick'em or bracket challenge.
+    Verified Tournament Challenge aliases include 'tcmen' and 'tcwomen'.
+    The live API also accepts season-specific keys such as
+    'tournament-challenge-bracket-2026' and
+    'tournament-challenge-bracket-women-2026'.
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         scoring_period_id (Union[Unset, int]):  Example: 1.
         view (Union[Unset, GetChallengeDetailsView]):  Example: picks.
 

--- a/models/gambit_api/espn_gambit_api_client/api/default/get_challenge_group.py
+++ b/models/gambit_api/espn_gambit_api_client/api/default/get_challenge_group.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -15,14 +15,14 @@ def _get_kwargs(
     group_id: str,
     *,
     view: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["view"] = view
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": f"/apis/v1/challenges/{challenge_name}/groups/{group_id}",
         "params": params,
@@ -71,7 +71,7 @@ def sync_detailed(
      Retrieve information about a specific group within a challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         group_id (str):
         view (Union[Unset, str]):
 
@@ -108,7 +108,7 @@ def sync(
      Retrieve information about a specific group within a challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         group_id (str):
         view (Union[Unset, str]):
 
@@ -140,7 +140,7 @@ async def asyncio_detailed(
      Retrieve information about a specific group within a challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         group_id (str):
         view (Union[Unset, str]):
 
@@ -175,7 +175,7 @@ async def asyncio(
      Retrieve information about a specific group within a challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         group_id (str):
         view (Union[Unset, str]):
 

--- a/models/gambit_api/espn_gambit_api_client/api/default/get_challenge_leaderboard.py
+++ b/models/gambit_api/espn_gambit_api_client/api/default/get_challenge_leaderboard.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -17,8 +17,8 @@ def _get_kwargs(
     view: Union[Unset, GetChallengeLeaderboardView] = UNSET,
     limit: Union[Unset, int] = 50,
     offset: Union[Unset, int] = 0,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     json_view: Union[Unset, str] = UNSET
     if not isinstance(view, Unset):
@@ -32,7 +32,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": f"/apis/v1/challenges/{challenge_name}/leaderboard",
         "params": params,
@@ -79,10 +79,10 @@ def sync_detailed(
 ) -> Response[Union[ErrorResponse, LeaderboardResponse]]:
     """Get Challenge Leaderboard
 
-     Retrieve the leaderboard for a specific Pick'em challenge
+     Retrieve the leaderboard for a specific Pick'em or bracket challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         view (Union[Unset, GetChallengeLeaderboardView]):  Example: ranks.
         limit (Union[Unset, int]):  Default: 50.
         offset (Union[Unset, int]):  Default: 0.
@@ -119,10 +119,10 @@ def sync(
 ) -> Optional[Union[ErrorResponse, LeaderboardResponse]]:
     """Get Challenge Leaderboard
 
-     Retrieve the leaderboard for a specific Pick'em challenge
+     Retrieve the leaderboard for a specific Pick'em or bracket challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         view (Union[Unset, GetChallengeLeaderboardView]):  Example: ranks.
         limit (Union[Unset, int]):  Default: 50.
         offset (Union[Unset, int]):  Default: 0.
@@ -154,10 +154,10 @@ async def asyncio_detailed(
 ) -> Response[Union[ErrorResponse, LeaderboardResponse]]:
     """Get Challenge Leaderboard
 
-     Retrieve the leaderboard for a specific Pick'em challenge
+     Retrieve the leaderboard for a specific Pick'em or bracket challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         view (Union[Unset, GetChallengeLeaderboardView]):  Example: ranks.
         limit (Union[Unset, int]):  Default: 50.
         offset (Union[Unset, int]):  Default: 0.
@@ -192,10 +192,10 @@ async def asyncio(
 ) -> Optional[Union[ErrorResponse, LeaderboardResponse]]:
     """Get Challenge Leaderboard
 
-     Retrieve the leaderboard for a specific Pick'em challenge
+     Retrieve the leaderboard for a specific Pick'em or bracket challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         view (Union[Unset, GetChallengeLeaderboardView]):  Example: ranks.
         limit (Union[Unset, int]):  Default: 50.
         offset (Union[Unset, int]):  Default: 0.

--- a/models/gambit_api/espn_gambit_api_client/api/default/get_propositions.py
+++ b/models/gambit_api/espn_gambit_api_client/api/default/get_propositions.py
@@ -1,21 +1,21 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.error_response import ErrorResponse
-from ...models.propositions_response import PropositionsResponse
+from ...models.proposition import Proposition
 from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
-    challenge_id: str,
+    challenge_id: int,
     view: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["challengeId"] = challenge_id
 
@@ -23,7 +23,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/apis/v1/propositions",
         "params": params,
@@ -34,9 +34,14 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[ErrorResponse, PropositionsResponse]]:
+) -> Optional[Union[ErrorResponse, list["Proposition"]]]:
     if response.status_code == 200:
-        response_200 = PropositionsResponse.from_dict(response.json())
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = Proposition.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
 
         return response_200
     if response.status_code == 404:
@@ -51,7 +56,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[ErrorResponse, PropositionsResponse]]:
+) -> Response[Union[ErrorResponse, list["Proposition"]]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,15 +68,18 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    challenge_id: str,
+    challenge_id: int,
     view: Union[Unset, str] = UNSET,
-) -> Response[Union[ErrorResponse, PropositionsResponse]]:
+) -> Response[Union[ErrorResponse, list["Proposition"]]]:
     """Get Propositions
 
-     Retrieve propositions (picks) for a challenge
+     Retrieve propositions (picks) for a challenge.
+    Note: the live API returns a top-level JSON array of proposition objects,
+    not an envelope object. Use the numeric challenge ID returned by
+    `/apis/v1/challenges/{challengeName}`.
 
     Args:
-        challenge_id (str):
+        challenge_id (int):
         view (Union[Unset, str]):
 
     Raises:
@@ -79,7 +87,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[ErrorResponse, PropositionsResponse]]
+        Response[Union[ErrorResponse, list['Proposition']]]
     """
 
     kwargs = _get_kwargs(
@@ -97,15 +105,18 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    challenge_id: str,
+    challenge_id: int,
     view: Union[Unset, str] = UNSET,
-) -> Optional[Union[ErrorResponse, PropositionsResponse]]:
+) -> Optional[Union[ErrorResponse, list["Proposition"]]]:
     """Get Propositions
 
-     Retrieve propositions (picks) for a challenge
+     Retrieve propositions (picks) for a challenge.
+    Note: the live API returns a top-level JSON array of proposition objects,
+    not an envelope object. Use the numeric challenge ID returned by
+    `/apis/v1/challenges/{challengeName}`.
 
     Args:
-        challenge_id (str):
+        challenge_id (int):
         view (Union[Unset, str]):
 
     Raises:
@@ -113,7 +124,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[ErrorResponse, PropositionsResponse]
+        Union[ErrorResponse, list['Proposition']]
     """
 
     return sync_detailed(
@@ -126,15 +137,18 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    challenge_id: str,
+    challenge_id: int,
     view: Union[Unset, str] = UNSET,
-) -> Response[Union[ErrorResponse, PropositionsResponse]]:
+) -> Response[Union[ErrorResponse, list["Proposition"]]]:
     """Get Propositions
 
-     Retrieve propositions (picks) for a challenge
+     Retrieve propositions (picks) for a challenge.
+    Note: the live API returns a top-level JSON array of proposition objects,
+    not an envelope object. Use the numeric challenge ID returned by
+    `/apis/v1/challenges/{challengeName}`.
 
     Args:
-        challenge_id (str):
+        challenge_id (int):
         view (Union[Unset, str]):
 
     Raises:
@@ -142,7 +156,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[ErrorResponse, PropositionsResponse]]
+        Response[Union[ErrorResponse, list['Proposition']]]
     """
 
     kwargs = _get_kwargs(
@@ -158,15 +172,18 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    challenge_id: str,
+    challenge_id: int,
     view: Union[Unset, str] = UNSET,
-) -> Optional[Union[ErrorResponse, PropositionsResponse]]:
+) -> Optional[Union[ErrorResponse, list["Proposition"]]]:
     """Get Propositions
 
-     Retrieve propositions (picks) for a challenge
+     Retrieve propositions (picks) for a challenge.
+    Note: the live API returns a top-level JSON array of proposition objects,
+    not an envelope object. Use the numeric challenge ID returned by
+    `/apis/v1/challenges/{challengeName}`.
 
     Args:
-        challenge_id (str):
+        challenge_id (int):
         view (Union[Unset, str]):
 
     Raises:
@@ -174,7 +191,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[ErrorResponse, PropositionsResponse]
+        Union[ErrorResponse, list['Proposition']]
     """
 
     return (

--- a/models/gambit_api/espn_gambit_api_client/api/default/get_user_entry.py
+++ b/models/gambit_api/espn_gambit_api_client/api/default/get_user_entry.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -15,14 +15,14 @@ def _get_kwargs(
     user_id: str,
     *,
     view: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["view"] = view
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": f"/apis/v1/challenges/{challenge_name}/entries/{user_id}",
         "params": params,
@@ -71,7 +71,7 @@ def sync_detailed(
      Retrieve a specific user's entry in a challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         user_id (str):
         view (Union[Unset, str]):
 
@@ -108,7 +108,7 @@ def sync(
      Retrieve a specific user's entry in a challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         user_id (str):
         view (Union[Unset, str]):
 
@@ -140,7 +140,7 @@ async def asyncio_detailed(
      Retrieve a specific user's entry in a challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         user_id (str):
         view (Union[Unset, str]):
 
@@ -175,7 +175,7 @@ async def asyncio(
      Retrieve a specific user's entry in a challenge
 
     Args:
-        challenge_name (str):  Example: nfl-pigskin-pickem-2025.
+        challenge_name (str):  Example: tcmen.
         user_id (str):
         view (Union[Unset, str]):
 

--- a/models/gambit_api/espn_gambit_api_client/client.py
+++ b/models/gambit_api/espn_gambit_api_client/client.py
@@ -38,9 +38,15 @@ class Client:
     _base_url: str = field(alias="base_url")
     _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
     _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
-    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
-    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
-    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _timeout: Optional[httpx.Timeout] = field(
+        default=None, kw_only=True, alias="timeout"
+    )
+    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
     _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
     _client: Optional[httpx.Client] = field(default=None, init=False)
     _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
@@ -168,9 +174,15 @@ class AuthenticatedClient:
     _base_url: str = field(alias="base_url")
     _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
     _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
-    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
-    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
-    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _timeout: Optional[httpx.Timeout] = field(
+        default=None, kw_only=True, alias="timeout"
+    )
+    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
     _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
     _client: Optional[httpx.Client] = field(default=None, init=False)
     _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
@@ -214,7 +226,9 @@ class AuthenticatedClient:
     def get_httpx_client(self) -> httpx.Client:
         """Get the underlying httpx.Client, constructing a new one if not previously set"""
         if self._client is None:
-            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
             self._client = httpx.Client(
                 base_url=self._base_url,
                 cookies=self._cookies,
@@ -235,7 +249,9 @@ class AuthenticatedClient:
         """Exit a context manager for internal httpx.Client (see httpx docs)"""
         self.get_httpx_client().__exit__(*args, **kwargs)
 
-    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "AuthenticatedClient":
+    def set_async_httpx_client(
+        self, async_client: httpx.AsyncClient
+    ) -> "AuthenticatedClient":
         """Manually the underlying httpx.AsyncClient
 
         **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
@@ -246,7 +262,9 @@ class AuthenticatedClient:
     def get_async_httpx_client(self) -> httpx.AsyncClient:
         """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
         if self._async_client is None:
-            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
             self._async_client = httpx.AsyncClient(
                 base_url=self._base_url,
                 cookies=self._cookies,

--- a/models/gambit_api/espn_gambit_api_client/client.py
+++ b/models/gambit_api/espn_gambit_api_client/client.py
@@ -1,5 +1,5 @@
 import ssl
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 from attrs import define, evolve, field
@@ -36,16 +36,16 @@ class Client:
 
     raise_on_unexpected_status: bool = field(default=False, kw_only=True)
     _base_url: str = field(alias="base_url")
-    _cookies: Dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
-    _headers: Dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
     _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
     _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
     _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
-    _httpx_args: Dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
     _client: Optional[httpx.Client] = field(default=None, init=False)
     _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
 
-    def with_headers(self, headers: Dict[str, str]) -> "Client":
+    def with_headers(self, headers: dict[str, str]) -> "Client":
         """Get a new client matching this one with additional headers"""
         if self._client is not None:
             self._client.headers.update(headers)
@@ -53,7 +53,7 @@ class Client:
             self._async_client.headers.update(headers)
         return evolve(self, headers={**self._headers, **headers})
 
-    def with_cookies(self, cookies: Dict[str, str]) -> "Client":
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
         """Get a new client matching this one with additional cookies"""
         if self._client is not None:
             self._client.cookies.update(cookies)
@@ -166,12 +166,12 @@ class AuthenticatedClient:
 
     raise_on_unexpected_status: bool = field(default=False, kw_only=True)
     _base_url: str = field(alias="base_url")
-    _cookies: Dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
-    _headers: Dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
     _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
     _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
     _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
-    _httpx_args: Dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
     _client: Optional[httpx.Client] = field(default=None, init=False)
     _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
 
@@ -179,7 +179,7 @@ class AuthenticatedClient:
     prefix: str = "Bearer"
     auth_header_name: str = "Authorization"
 
-    def with_headers(self, headers: Dict[str, str]) -> "AuthenticatedClient":
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
         """Get a new client matching this one with additional headers"""
         if self._client is not None:
             self._client.headers.update(headers)
@@ -187,7 +187,7 @@ class AuthenticatedClient:
             self._async_client.headers.update(headers)
         return evolve(self, headers={**self._headers, **headers})
 
-    def with_cookies(self, cookies: Dict[str, str]) -> "AuthenticatedClient":
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
         """Get a new client matching this one with additional cookies"""
         if self._client is not None:
             self._client.cookies.update(cookies)

--- a/models/gambit_api/espn_gambit_api_client/models/__init__.py
+++ b/models/gambit_api/espn_gambit_api_client/models/__init__.py
@@ -7,7 +7,9 @@ from .entry_response import EntryResponse
 from .entry_response_picks_item import EntryResponsePicksItem
 from .error_response import ErrorResponse
 from .error_response_details_item import ErrorResponseDetailsItem
-from .error_response_details_item_meta_data_type_0 import ErrorResponseDetailsItemMetaDataType0
+from .error_response_details_item_meta_data_type_0 import (
+    ErrorResponseDetailsItemMetaDataType0,
+)
 from .get_challenge_details_view import GetChallengeDetailsView
 from .get_challenge_leaderboard_view import GetChallengeLeaderboardView
 from .group_response import GroupResponse

--- a/models/gambit_api/espn_gambit_api_client/models/challenge_response.py
+++ b/models/gambit_api/espn_gambit_api_client/models/challenge_response.py
@@ -7,7 +7,9 @@ from attrs import field as _attrs_field
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
-    from ..models.challenge_response_scoring_periods_item import ChallengeResponseScoringPeriodsItem
+    from ..models.challenge_response_scoring_periods_item import (
+        ChallengeResponseScoringPeriodsItem,
+    )
     from ..models.challenge_response_settings import ChallengeResponseSettings
     from ..models.proposition import Proposition
 
@@ -136,7 +138,9 @@ class ChallengeResponse:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.challenge_response_scoring_periods_item import ChallengeResponseScoringPeriodsItem
+        from ..models.challenge_response_scoring_periods_item import (
+            ChallengeResponseScoringPeriodsItem,
+        )
         from ..models.challenge_response_settings import ChallengeResponseSettings
         from ..models.proposition import Proposition
 
@@ -180,11 +184,15 @@ class ChallengeResponse:
         scoring_periods = []
         _scoring_periods = d.pop("scoringPeriods", UNSET)
         for scoring_periods_item_data in _scoring_periods or []:
-            scoring_periods_item = ChallengeResponseScoringPeriodsItem.from_dict(scoring_periods_item_data)
+            scoring_periods_item = ChallengeResponseScoringPeriodsItem.from_dict(
+                scoring_periods_item_data
+            )
 
             scoring_periods.append(scoring_periods_item)
 
-        leaderboard_sort_options = cast(list[str], d.pop("leaderboardSortOptions", UNSET))
+        leaderboard_sort_options = cast(
+            list[str], d.pop("leaderboardSortOptions", UNSET)
+        )
 
         challenge_response = cls(
             id=id,

--- a/models/gambit_api/espn_gambit_api_client/models/challenge_response.py
+++ b/models/gambit_api/espn_gambit_api_client/models/challenge_response.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -18,8 +19,8 @@ T = TypeVar("T", bound="ChallengeResponse")
 class ChallengeResponse:
     """
     Attributes:
-        id (Union[Unset, str]): Challenge ID
-        key (Union[Unset, str]): Challenge key/name
+        id (Union[Unset, int]): Challenge ID
+        key (Union[Unset, str]): Canonical challenge key/name
         name (Union[Unset, str]): Display name
         abbrev (Union[Unset, str]): Abbreviation
         active (Union[Unset, bool]):
@@ -30,12 +31,12 @@ class ChallengeResponse:
         end_date (Union[Unset, int]): End date as Unix timestamp in milliseconds
         state (Union[Unset, str]): Challenge state (e.g., 'active')
         settings (Union[Unset, ChallengeResponseSettings]):
-        propositions (Union[Unset, List['Proposition']]):
-        scoring_periods (Union[Unset, List['ChallengeResponseScoringPeriodsItem']]):
-        leaderboard_sort_options (Union[Unset, List[str]]):
+        propositions (Union[Unset, list['Proposition']]):
+        scoring_periods (Union[Unset, list['ChallengeResponseScoringPeriodsItem']]):
+        leaderboard_sort_options (Union[Unset, list[str]]):
     """
 
-    id: Union[Unset, str] = UNSET
+    id: Union[Unset, int] = UNSET
     key: Union[Unset, str] = UNSET
     name: Union[Unset, str] = UNSET
     abbrev: Union[Unset, str] = UNSET
@@ -47,12 +48,12 @@ class ChallengeResponse:
     end_date: Union[Unset, int] = UNSET
     state: Union[Unset, str] = UNSET
     settings: Union[Unset, "ChallengeResponseSettings"] = UNSET
-    propositions: Union[Unset, List["Proposition"]] = UNSET
-    scoring_periods: Union[Unset, List["ChallengeResponseScoringPeriodsItem"]] = UNSET
-    leaderboard_sort_options: Union[Unset, List[str]] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    propositions: Union[Unset, list["Proposition"]] = UNSET
+    scoring_periods: Union[Unset, list["ChallengeResponseScoringPeriodsItem"]] = UNSET
+    leaderboard_sort_options: Union[Unset, list[str]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         key = self.key
@@ -75,29 +76,29 @@ class ChallengeResponse:
 
         state = self.state
 
-        settings: Union[Unset, Dict[str, Any]] = UNSET
+        settings: Union[Unset, dict[str, Any]] = UNSET
         if not isinstance(self.settings, Unset):
             settings = self.settings.to_dict()
 
-        propositions: Union[Unset, List[Dict[str, Any]]] = UNSET
+        propositions: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.propositions, Unset):
             propositions = []
             for propositions_item_data in self.propositions:
                 propositions_item = propositions_item_data.to_dict()
                 propositions.append(propositions_item)
 
-        scoring_periods: Union[Unset, List[Dict[str, Any]]] = UNSET
+        scoring_periods: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.scoring_periods, Unset):
             scoring_periods = []
             for scoring_periods_item_data in self.scoring_periods:
                 scoring_periods_item = scoring_periods_item_data.to_dict()
                 scoring_periods.append(scoring_periods_item)
 
-        leaderboard_sort_options: Union[Unset, List[str]] = UNSET
+        leaderboard_sort_options: Union[Unset, list[str]] = UNSET
         if not isinstance(self.leaderboard_sort_options, Unset):
             leaderboard_sort_options = self.leaderboard_sort_options
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not UNSET:
@@ -134,12 +135,12 @@ class ChallengeResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.challenge_response_scoring_periods_item import ChallengeResponseScoringPeriodsItem
         from ..models.challenge_response_settings import ChallengeResponseSettings
         from ..models.proposition import Proposition
 
-        d = src_dict.copy()
+        d = dict(src_dict)
         id = d.pop("id", UNSET)
 
         key = d.pop("key", UNSET)
@@ -183,7 +184,7 @@ class ChallengeResponse:
 
             scoring_periods.append(scoring_periods_item)
 
-        leaderboard_sort_options = cast(List[str], d.pop("leaderboardSortOptions", UNSET))
+        leaderboard_sort_options = cast(list[str], d.pop("leaderboardSortOptions", UNSET))
 
         challenge_response = cls(
             id=id,
@@ -207,7 +208,7 @@ class ChallengeResponse:
         return challenge_response
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/challenge_response_scoring_periods_item.py
+++ b/models/gambit_api/espn_gambit_api_client/models/challenge_response_scoring_periods_item.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Type, TypeVar
+from collections.abc import Mapping
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,24 +11,24 @@ T = TypeVar("T", bound="ChallengeResponseScoringPeriodsItem")
 class ChallengeResponseScoringPeriodsItem:
     """ """
 
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
         challenge_response_scoring_periods_item = cls()
 
         challenge_response_scoring_periods_item.additional_properties = d
         return challenge_response_scoring_periods_item
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/challenge_response_settings.py
+++ b/models/gambit_api/espn_gambit_api_client/models/challenge_response_settings.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Type, TypeVar
+from collections.abc import Mapping
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,24 +11,24 @@ T = TypeVar("T", bound="ChallengeResponseSettings")
 class ChallengeResponseSettings:
     """ """
 
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
         challenge_response_settings = cls()
 
         challenge_response_settings.additional_properties = d
         return challenge_response_settings
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/entry_response.py
+++ b/models/gambit_api/espn_gambit_api_client/models/entry_response.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -18,34 +19,34 @@ class EntryResponse:
     Attributes:
         id (Union[Unset, str]):
         user_id (Union[Unset, str]):
-        challenge_id (Union[Unset, str]):
-        group_ids (Union[Unset, List[str]]):
-        picks (Union[Unset, List['EntryResponsePicksItem']]):
+        challenge_id (Union[Unset, int]):
+        group_ids (Union[Unset, list[str]]):
+        picks (Union[Unset, list['EntryResponsePicksItem']]):
         score (Union[Unset, float]):
         rank (Union[Unset, int]):
     """
 
     id: Union[Unset, str] = UNSET
     user_id: Union[Unset, str] = UNSET
-    challenge_id: Union[Unset, str] = UNSET
-    group_ids: Union[Unset, List[str]] = UNSET
-    picks: Union[Unset, List["EntryResponsePicksItem"]] = UNSET
+    challenge_id: Union[Unset, int] = UNSET
+    group_ids: Union[Unset, list[str]] = UNSET
+    picks: Union[Unset, list["EntryResponsePicksItem"]] = UNSET
     score: Union[Unset, float] = UNSET
     rank: Union[Unset, int] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         user_id = self.user_id
 
         challenge_id = self.challenge_id
 
-        group_ids: Union[Unset, List[str]] = UNSET
+        group_ids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.group_ids, Unset):
             group_ids = self.group_ids
 
-        picks: Union[Unset, List[Dict[str, Any]]] = UNSET
+        picks: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.picks, Unset):
             picks = []
             for picks_item_data in self.picks:
@@ -56,7 +57,7 @@ class EntryResponse:
 
         rank = self.rank
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not UNSET:
@@ -77,17 +78,17 @@ class EntryResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.entry_response_picks_item import EntryResponsePicksItem
 
-        d = src_dict.copy()
+        d = dict(src_dict)
         id = d.pop("id", UNSET)
 
         user_id = d.pop("userId", UNSET)
 
         challenge_id = d.pop("challengeId", UNSET)
 
-        group_ids = cast(List[str], d.pop("groupIds", UNSET))
+        group_ids = cast(list[str], d.pop("groupIds", UNSET))
 
         picks = []
         _picks = d.pop("picks", UNSET)
@@ -114,7 +115,7 @@ class EntryResponse:
         return entry_response
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/entry_response_picks_item.py
+++ b/models/gambit_api/espn_gambit_api_client/models/entry_response_picks_item.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Type, TypeVar
+from collections.abc import Mapping
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,24 +11,24 @@ T = TypeVar("T", bound="EntryResponsePicksItem")
 class EntryResponsePicksItem:
     """ """
 
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
         entry_response_picks_item = cls()
 
         entry_response_picks_item.additional_properties = d
         return entry_response_picks_item
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/error_response.py
+++ b/models/gambit_api/espn_gambit_api_client/models/error_response.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -16,27 +17,27 @@ T = TypeVar("T", bound="ErrorResponse")
 class ErrorResponse:
     """
     Attributes:
-        messages (Union[Unset, List[str]]):
-        details (Union[Unset, List['ErrorResponseDetailsItem']]):
+        messages (Union[Unset, list[str]]):
+        details (Union[Unset, list['ErrorResponseDetailsItem']]):
     """
 
-    messages: Union[Unset, List[str]] = UNSET
-    details: Union[Unset, List["ErrorResponseDetailsItem"]] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    messages: Union[Unset, list[str]] = UNSET
+    details: Union[Unset, list["ErrorResponseDetailsItem"]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        messages: Union[Unset, List[str]] = UNSET
+    def to_dict(self) -> dict[str, Any]:
+        messages: Union[Unset, list[str]] = UNSET
         if not isinstance(self.messages, Unset):
             messages = self.messages
 
-        details: Union[Unset, List[Dict[str, Any]]] = UNSET
+        details: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.details, Unset):
             details = []
             for details_item_data in self.details:
                 details_item = details_item_data.to_dict()
                 details.append(details_item)
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if messages is not UNSET:
@@ -47,11 +48,11 @@ class ErrorResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.error_response_details_item import ErrorResponseDetailsItem
 
-        d = src_dict.copy()
-        messages = cast(List[str], d.pop("messages", UNSET))
+        d = dict(src_dict)
+        messages = cast(list[str], d.pop("messages", UNSET))
 
         details = []
         _details = d.pop("details", UNSET)
@@ -69,7 +70,7 @@ class ErrorResponse:
         return error_response
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/error_response_details_item.py
+++ b/models/gambit_api/espn_gambit_api_client/models/error_response_details_item.py
@@ -7,7 +7,9 @@ from attrs import field as _attrs_field
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
-    from ..models.error_response_details_item_meta_data_type_0 import ErrorResponseDetailsItemMetaDataType0
+    from ..models.error_response_details_item_meta_data_type_0 import (
+        ErrorResponseDetailsItemMetaDataType0,
+    )
 
 
 T = TypeVar("T", bound="ErrorResponseDetailsItem")
@@ -32,7 +34,9 @@ class ErrorResponseDetailsItem:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.error_response_details_item_meta_data_type_0 import ErrorResponseDetailsItemMetaDataType0
+        from ..models.error_response_details_item_meta_data_type_0 import (
+            ErrorResponseDetailsItemMetaDataType0,
+        )
 
         message = self.message
 
@@ -72,7 +76,9 @@ class ErrorResponseDetailsItem:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.error_response_details_item_meta_data_type_0 import ErrorResponseDetailsItemMetaDataType0
+        from ..models.error_response_details_item_meta_data_type_0 import (
+            ErrorResponseDetailsItemMetaDataType0,
+        )
 
         d = dict(src_dict)
         message = d.pop("message", UNSET)
@@ -90,7 +96,9 @@ class ErrorResponseDetailsItem:
 
         type_ = d.pop("type", UNSET)
 
-        def _parse_meta_data(data: object) -> Union["ErrorResponseDetailsItemMetaDataType0", None, Unset]:
+        def _parse_meta_data(
+            data: object,
+        ) -> Union["ErrorResponseDetailsItemMetaDataType0", None, Unset]:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -103,7 +111,9 @@ class ErrorResponseDetailsItem:
                 return meta_data_type_0
             except:  # noqa: E722
                 pass
-            return cast(Union["ErrorResponseDetailsItemMetaDataType0", None, Unset], data)
+            return cast(
+                Union["ErrorResponseDetailsItemMetaDataType0", None, Unset], data
+            )
 
         meta_data = _parse_meta_data(d.pop("metaData", UNSET))
 

--- a/models/gambit_api/espn_gambit_api_client/models/error_response_details_item.py
+++ b/models/gambit_api/espn_gambit_api_client/models/error_response_details_item.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -19,18 +20,18 @@ class ErrorResponseDetailsItem:
         message (Union[Unset, str]):
         short_message (Union[Unset, str]):
         resolution (Union[None, Unset, str]):
-        type (Union[Unset, str]):
+        type_ (Union[Unset, str]):
         meta_data (Union['ErrorResponseDetailsItemMetaDataType0', None, Unset]):
     """
 
     message: Union[Unset, str] = UNSET
     short_message: Union[Unset, str] = UNSET
     resolution: Union[None, Unset, str] = UNSET
-    type: Union[Unset, str] = UNSET
+    type_: Union[Unset, str] = UNSET
     meta_data: Union["ErrorResponseDetailsItemMetaDataType0", None, Unset] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         from ..models.error_response_details_item_meta_data_type_0 import ErrorResponseDetailsItemMetaDataType0
 
         message = self.message
@@ -43,9 +44,9 @@ class ErrorResponseDetailsItem:
         else:
             resolution = self.resolution
 
-        type = self.type
+        type_ = self.type_
 
-        meta_data: Union[Dict[str, Any], None, Unset]
+        meta_data: Union[None, Unset, dict[str, Any]]
         if isinstance(self.meta_data, Unset):
             meta_data = UNSET
         elif isinstance(self.meta_data, ErrorResponseDetailsItemMetaDataType0):
@@ -53,7 +54,7 @@ class ErrorResponseDetailsItem:
         else:
             meta_data = self.meta_data
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if message is not UNSET:
@@ -62,18 +63,18 @@ class ErrorResponseDetailsItem:
             field_dict["shortMessage"] = short_message
         if resolution is not UNSET:
             field_dict["resolution"] = resolution
-        if type is not UNSET:
-            field_dict["type"] = type
+        if type_ is not UNSET:
+            field_dict["type"] = type_
         if meta_data is not UNSET:
             field_dict["metaData"] = meta_data
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.error_response_details_item_meta_data_type_0 import ErrorResponseDetailsItemMetaDataType0
 
-        d = src_dict.copy()
+        d = dict(src_dict)
         message = d.pop("message", UNSET)
 
         short_message = d.pop("shortMessage", UNSET)
@@ -87,7 +88,7 @@ class ErrorResponseDetailsItem:
 
         resolution = _parse_resolution(d.pop("resolution", UNSET))
 
-        type = d.pop("type", UNSET)
+        type_ = d.pop("type", UNSET)
 
         def _parse_meta_data(data: object) -> Union["ErrorResponseDetailsItemMetaDataType0", None, Unset]:
             if data is None:
@@ -110,7 +111,7 @@ class ErrorResponseDetailsItem:
             message=message,
             short_message=short_message,
             resolution=resolution,
-            type=type,
+            type_=type_,
             meta_data=meta_data,
         )
 
@@ -118,7 +119,7 @@ class ErrorResponseDetailsItem:
         return error_response_details_item
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/error_response_details_item_meta_data_type_0.py
+++ b/models/gambit_api/espn_gambit_api_client/models/error_response_details_item_meta_data_type_0.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Type, TypeVar
+from collections.abc import Mapping
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,24 +11,24 @@ T = TypeVar("T", bound="ErrorResponseDetailsItemMetaDataType0")
 class ErrorResponseDetailsItemMetaDataType0:
     """ """
 
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
         error_response_details_item_meta_data_type_0 = cls()
 
         error_response_details_item_meta_data_type_0.additional_properties = d
         return error_response_details_item_meta_data_type_0
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/group_response.py
+++ b/models/gambit_api/espn_gambit_api_client/models/group_response.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -18,19 +19,19 @@ class GroupResponse:
     Attributes:
         id (Union[Unset, str]):
         name (Union[Unset, str]):
-        challenge_id (Union[Unset, str]):
+        challenge_id (Union[Unset, int]):
         size (Union[Unset, int]):
         settings (Union[Unset, GroupResponseSettings]):
     """
 
     id: Union[Unset, str] = UNSET
     name: Union[Unset, str] = UNSET
-    challenge_id: Union[Unset, str] = UNSET
+    challenge_id: Union[Unset, int] = UNSET
     size: Union[Unset, int] = UNSET
     settings: Union[Unset, "GroupResponseSettings"] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         name = self.name
@@ -39,11 +40,11 @@ class GroupResponse:
 
         size = self.size
 
-        settings: Union[Unset, Dict[str, Any]] = UNSET
+        settings: Union[Unset, dict[str, Any]] = UNSET
         if not isinstance(self.settings, Unset):
             settings = self.settings.to_dict()
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not UNSET:
@@ -60,10 +61,10 @@ class GroupResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.group_response_settings import GroupResponseSettings
 
-        d = src_dict.copy()
+        d = dict(src_dict)
         id = d.pop("id", UNSET)
 
         name = d.pop("name", UNSET)
@@ -91,7 +92,7 @@ class GroupResponse:
         return group_response
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/group_response_settings.py
+++ b/models/gambit_api/espn_gambit_api_client/models/group_response_settings.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Type, TypeVar
+from collections.abc import Mapping
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,24 +11,24 @@ T = TypeVar("T", bound="GroupResponseSettings")
 class GroupResponseSettings:
     """ """
 
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
         group_response_settings = cls()
 
         group_response_settings.additional_properties = d
         return group_response_settings
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/leaderboard_entry.py
+++ b/models/gambit_api/espn_gambit_api_client/models/leaderboard_entry.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -28,9 +29,9 @@ class LeaderboardEntry:
     user_name: Union[Unset, str] = UNSET
     display_name: Union[Unset, str] = UNSET
     profile_image_url: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         rank = self.rank
@@ -49,7 +50,7 @@ class LeaderboardEntry:
         else:
             profile_image_url = self.profile_image_url
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not UNSET:
@@ -70,8 +71,8 @@ class LeaderboardEntry:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
         id = d.pop("id", UNSET)
 
         rank = d.pop("rank", UNSET)
@@ -107,7 +108,7 @@ class LeaderboardEntry:
         return leaderboard_entry
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/leaderboard_response.py
+++ b/models/gambit_api/espn_gambit_api_client/models/leaderboard_response.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -16,23 +17,23 @@ T = TypeVar("T", bound="LeaderboardResponse")
 class LeaderboardResponse:
     """
     Attributes:
-        challenge_id (Union[Unset, str]):
+        challenge_id (Union[Unset, int]):
         group_id (Union[None, Unset, str]):
         size (Union[Unset, int]): Total number of entries
         locked (Union[Unset, bool]):
-        entries (Union[Unset, List['LeaderboardEntry']]):
-        featured_entry_ids (Union[Unset, List[str]]):
+        entries (Union[Unset, list['LeaderboardEntry']]):
+        featured_entry_ids (Union[Unset, list[str]]):
     """
 
-    challenge_id: Union[Unset, str] = UNSET
+    challenge_id: Union[Unset, int] = UNSET
     group_id: Union[None, Unset, str] = UNSET
     size: Union[Unset, int] = UNSET
     locked: Union[Unset, bool] = UNSET
-    entries: Union[Unset, List["LeaderboardEntry"]] = UNSET
-    featured_entry_ids: Union[Unset, List[str]] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    entries: Union[Unset, list["LeaderboardEntry"]] = UNSET
+    featured_entry_ids: Union[Unset, list[str]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         challenge_id = self.challenge_id
 
         group_id: Union[None, Unset, str]
@@ -45,18 +46,18 @@ class LeaderboardResponse:
 
         locked = self.locked
 
-        entries: Union[Unset, List[Dict[str, Any]]] = UNSET
+        entries: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.entries, Unset):
             entries = []
             for entries_item_data in self.entries:
                 entries_item = entries_item_data.to_dict()
                 entries.append(entries_item)
 
-        featured_entry_ids: Union[Unset, List[str]] = UNSET
+        featured_entry_ids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.featured_entry_ids, Unset):
             featured_entry_ids = self.featured_entry_ids
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if challenge_id is not UNSET:
@@ -75,10 +76,10 @@ class LeaderboardResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.leaderboard_entry import LeaderboardEntry
 
-        d = src_dict.copy()
+        d = dict(src_dict)
         challenge_id = d.pop("challengeId", UNSET)
 
         def _parse_group_id(data: object) -> Union[None, Unset, str]:
@@ -101,7 +102,7 @@ class LeaderboardResponse:
 
             entries.append(entries_item)
 
-        featured_entry_ids = cast(List[str], d.pop("featuredEntryIds", UNSET))
+        featured_entry_ids = cast(list[str], d.pop("featuredEntryIds", UNSET))
 
         leaderboard_response = cls(
             challenge_id=challenge_id,
@@ -116,7 +117,7 @@ class LeaderboardResponse:
         return leaderboard_response
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/proposition.py
+++ b/models/gambit_api/espn_gambit_api_client/models/proposition.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,27 +18,27 @@ class Proposition:
     """
     Attributes:
         id (Union[Unset, str]):
-        type (Union[Unset, str]):
+        type_ (Union[Unset, str]):
         text (Union[Unset, str]):
         short_text (Union[Unset, str]):
         locked (Union[Unset, bool]):
         scoring_period_id (Union[Unset, int]):
-        options (Union[Unset, List['PropositionOptionsItem']]):
+        options (Union[Unset, list['PropositionOptionsItem']]):
     """
 
     id: Union[Unset, str] = UNSET
-    type: Union[Unset, str] = UNSET
+    type_: Union[Unset, str] = UNSET
     text: Union[Unset, str] = UNSET
     short_text: Union[Unset, str] = UNSET
     locked: Union[Unset, bool] = UNSET
     scoring_period_id: Union[Unset, int] = UNSET
-    options: Union[Unset, List["PropositionOptionsItem"]] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    options: Union[Unset, list["PropositionOptionsItem"]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
-        type = self.type
+        type_ = self.type_
 
         text = self.text
 
@@ -47,20 +48,20 @@ class Proposition:
 
         scoring_period_id = self.scoring_period_id
 
-        options: Union[Unset, List[Dict[str, Any]]] = UNSET
+        options: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.options, Unset):
             options = []
             for options_item_data in self.options:
                 options_item = options_item_data.to_dict()
                 options.append(options_item)
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not UNSET:
             field_dict["id"] = id
-        if type is not UNSET:
-            field_dict["type"] = type
+        if type_ is not UNSET:
+            field_dict["type"] = type_
         if text is not UNSET:
             field_dict["text"] = text
         if short_text is not UNSET:
@@ -75,13 +76,13 @@ class Proposition:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.proposition_options_item import PropositionOptionsItem
 
-        d = src_dict.copy()
+        d = dict(src_dict)
         id = d.pop("id", UNSET)
 
-        type = d.pop("type", UNSET)
+        type_ = d.pop("type", UNSET)
 
         text = d.pop("text", UNSET)
 
@@ -100,7 +101,7 @@ class Proposition:
 
         proposition = cls(
             id=id,
-            type=type,
+            type_=type_,
             text=text,
             short_text=short_text,
             locked=locked,
@@ -112,7 +113,7 @@ class Proposition:
         return proposition
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/proposition_options_item.py
+++ b/models/gambit_api/espn_gambit_api_client/models/proposition_options_item.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -20,9 +21,9 @@ class PropositionOptionsItem:
     id: Union[Unset, str] = UNSET
     text: Union[Unset, str] = UNSET
     winner: Union[None, Unset, bool] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         text = self.text
@@ -33,7 +34,7 @@ class PropositionOptionsItem:
         else:
             winner = self.winner
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not UNSET:
@@ -46,8 +47,8 @@ class PropositionOptionsItem:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
         id = d.pop("id", UNSET)
 
         text = d.pop("text", UNSET)
@@ -71,7 +72,7 @@ class PropositionOptionsItem:
         return proposition_options_item
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/models/propositions_response.py
+++ b/models/gambit_api/espn_gambit_api_client/models/propositions_response.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -16,25 +17,25 @@ T = TypeVar("T", bound="PropositionsResponse")
 class PropositionsResponse:
     """
     Attributes:
-        challenge_id (Union[Unset, str]):
-        propositions (Union[Unset, List['Proposition']]):
+        challenge_id (Union[Unset, int]):
+        propositions (Union[Unset, list['Proposition']]):
     """
 
-    challenge_id: Union[Unset, str] = UNSET
-    propositions: Union[Unset, List["Proposition"]] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    challenge_id: Union[Unset, int] = UNSET
+    propositions: Union[Unset, list["Proposition"]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         challenge_id = self.challenge_id
 
-        propositions: Union[Unset, List[Dict[str, Any]]] = UNSET
+        propositions: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.propositions, Unset):
             propositions = []
             for propositions_item_data in self.propositions:
                 propositions_item = propositions_item_data.to_dict()
                 propositions.append(propositions_item)
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if challenge_id is not UNSET:
@@ -45,10 +46,10 @@ class PropositionsResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.proposition import Proposition
 
-        d = src_dict.copy()
+        d = dict(src_dict)
         challenge_id = d.pop("challengeId", UNSET)
 
         propositions = []
@@ -67,7 +68,7 @@ class PropositionsResponse:
         return propositions_response
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/gambit_api/espn_gambit_api_client/types.py
+++ b/models/gambit_api/espn_gambit_api_client/types.py
@@ -1,7 +1,8 @@
 """Contains some shared types for properties"""
 
+from collections.abc import MutableMapping
 from http import HTTPStatus
-from typing import BinaryIO, Generic, Literal, MutableMapping, Optional, Tuple, TypeVar
+from typing import BinaryIO, Generic, Literal, Optional, TypeVar
 
 from attrs import define
 
@@ -13,7 +14,7 @@ class Unset:
 
 UNSET: Unset = Unset()
 
-FileJsonType = Tuple[Optional[str], BinaryIO, Optional[str]]
+FileJsonType = tuple[Optional[str], BinaryIO, Optional[str]]
 
 
 @define
@@ -42,4 +43,4 @@ class Response(Generic[T]):
     parsed: Optional[T]
 
 
-__all__ = ["File", "Response", "FileJsonType", "Unset", "UNSET"]
+__all__ = ["UNSET", "File", "FileJsonType", "Response", "Unset"]

--- a/models/gambit_api/pyproject.toml
+++ b/models/gambit_api/pyproject.toml
@@ -11,9 +11,9 @@ include = ["CHANGELOG.md", "espn_gambit_api_client/py.typed"]
 
 
 [tool.poetry.dependencies]
-python = "^3.8"
-httpx = ">=0.20.0,<0.28.0"
-attrs = ">=21.3.0"
+python = "^3.9"
+httpx = ">=0.20.0,<0.29.0"
+attrs = ">=22.2.0"
 python-dateutil = "^2.8.0"
 
 [build-system]

--- a/models/site_web_api/espn_site_web_api_client/models/athlete_profile_response_athlete.py
+++ b/models/site_web_api/espn_site_web_api_client/models/athlete_profile_response_athlete.py
@@ -1,7 +1,9 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.athlete_profile_response_athlete_college import AthleteProfileResponseAthleteCollege
@@ -26,7 +28,7 @@ class AthleteProfileResponseAthlete:
         last_name (str):
         display_name (str):
         full_name (str):
-        jersey (str):
+        jersey (Union[Unset, str]): Omitted when athlete has no assigned number.
         position (Position):
         age (int):
         display_height (str):
@@ -45,7 +47,6 @@ class AthleteProfileResponseAthlete:
     last_name: str
     display_name: str
     full_name: str
-    jersey: str
     position: "Position"
     age: int
     display_height: str
@@ -54,6 +55,7 @@ class AthleteProfileResponseAthlete:
     team: "Team"
     headshot: "Headshot"
     status: "Status"
+    jersey: Union[Unset, str] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -73,8 +75,6 @@ class AthleteProfileResponseAthlete:
 
         full_name = self.full_name
 
-        jersey = self.jersey
-
         position = self.position.to_dict()
 
         age = self.age
@@ -91,6 +91,8 @@ class AthleteProfileResponseAthlete:
 
         status = self.status.to_dict()
 
+        jersey = self.jersey
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -103,7 +105,6 @@ class AthleteProfileResponseAthlete:
                 "lastName": last_name,
                 "displayName": display_name,
                 "fullName": full_name,
-                "jersey": jersey,
                 "position": position,
                 "age": age,
                 "displayHeight": display_height,
@@ -114,6 +115,8 @@ class AthleteProfileResponseAthlete:
                 "status": status,
             }
         )
+        if jersey is not UNSET:
+            field_dict["jersey"] = jersey
 
         return field_dict
 
@@ -142,8 +145,6 @@ class AthleteProfileResponseAthlete:
 
         full_name = d.pop("fullName")
 
-        jersey = d.pop("jersey")
-
         position = Position.from_dict(d.pop("position"))
 
         age = d.pop("age")
@@ -160,6 +161,8 @@ class AthleteProfileResponseAthlete:
 
         status = Status.from_dict(d.pop("status"))
 
+        jersey = d.pop("jersey", UNSET)
+
         athlete_profile_response_athlete = cls(
             id=id,
             uid=uid,
@@ -169,7 +172,6 @@ class AthleteProfileResponseAthlete:
             last_name=last_name,
             display_name=display_name,
             full_name=full_name,
-            jersey=jersey,
             position=position,
             age=age,
             display_height=display_height,
@@ -178,6 +180,7 @@ class AthleteProfileResponseAthlete:
             team=team,
             headshot=headshot,
             status=status,
+            jersey=jersey,
         )
 
         athlete_profile_response_athlete.additional_properties = d

--- a/models/site_web_api/espn_site_web_api_client/models/athlete_profile_response_athlete.py
+++ b/models/site_web_api/espn_site_web_api_client/models/athlete_profile_response_athlete.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -6,7 +6,9 @@ from attrs import field as _attrs_field
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
-    from ..models.athlete_profile_response_athlete_college import AthleteProfileResponseAthleteCollege
+    from ..models.athlete_profile_response_athlete_college import (
+        AthleteProfileResponseAthleteCollege,
+    )
     from ..models.headshot import Headshot
     from ..models.position import Position
     from ..models.status import Status
@@ -56,9 +58,9 @@ class AthleteProfileResponseAthlete:
     headshot: "Headshot"
     status: "Status"
     jersey: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         uid = self.uid
@@ -93,7 +95,7 @@ class AthleteProfileResponseAthlete:
 
         jersey = self.jersey
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -121,8 +123,10 @@ class AthleteProfileResponseAthlete:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.athlete_profile_response_athlete_college import AthleteProfileResponseAthleteCollege
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
+        from ..models.athlete_profile_response_athlete_college import (
+            AthleteProfileResponseAthleteCollege,
+        )
         from ..models.headshot import Headshot
         from ..models.position import Position
         from ..models.status import Status
@@ -187,7 +191,7 @@ class AthleteProfileResponseAthlete:
         return athlete_profile_response_athlete
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/sports_core_api/espn_sports_core_api_client/models/athlete_note.py
+++ b/models/sports_core_api/espn_sports_core_api_client/models/athlete_note.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -29,9 +29,9 @@ class AthleteNote:
     source: str
     headline: Union[Unset, str] = UNSET
     text: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         type = self.type
@@ -52,7 +52,7 @@ class AthleteNote:
 
         source = self.source
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -70,7 +70,7 @@ class AthleteNote:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         id = d.pop("id")
 
@@ -97,7 +97,7 @@ class AthleteNote:
         return athlete_note
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/models/sports_core_api/espn_sports_core_api_client/models/athlete_note.py
+++ b/models/sports_core_api/espn_sports_core_api_client/models/athlete_note.py
@@ -1,9 +1,11 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="AthleteNote")
 
@@ -16,19 +18,17 @@ class AthleteNote:
         id (str): Unique identifier for the note Example: 597206.
         type (str): Type of note (e.g., news) Example: news.
         date (datetime.datetime): Date and time of the note Example: 2025-03-12T15:55Z.
-        headline (str): Brief summary of the note Example: Mahomes agreed Wednesday with the Chiefs on a restructure of
-            his contract, Adam Teicher of ESPN.com reports..
-        text (str): Full text of the note Example: Mahomes and star defensive tackle Chris Jones both agreed to
-            restructure their contracts Wednesday....
+        headline (Union[Unset, str]): Brief summary of the note (may be omitted by API).
+        text (Union[Unset, str]): Full text of the note (may be omitted by API).
         source (str): Source of the note Example: RotoWire.
     """
 
     id: str
     type: str
     date: datetime.datetime
-    headline: str
-    text: str
     source: str
+    headline: Union[Unset, str] = UNSET
+    text: Union[Unset, str] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -38,9 +38,17 @@ class AthleteNote:
 
         date = self.date.isoformat()
 
-        headline = self.headline
+        headline: Union[Unset, str]
+        if isinstance(self.headline, Unset):
+            headline = UNSET
+        else:
+            headline = self.headline
 
-        text = self.text
+        text: Union[Unset, str]
+        if isinstance(self.text, Unset):
+            text = UNSET
+        else:
+            text = self.text
 
         source = self.source
 
@@ -51,11 +59,13 @@ class AthleteNote:
                 "id": id,
                 "type": type,
                 "date": date,
-                "headline": headline,
-                "text": text,
                 "source": source,
             }
         )
+        if headline is not UNSET:
+            field_dict["headline"] = headline
+        if text is not UNSET:
+            field_dict["text"] = text
 
         return field_dict
 
@@ -68,9 +78,9 @@ class AthleteNote:
 
         date = isoparse(d.pop("date"))
 
-        headline = d.pop("headline")
+        headline = d.pop("headline", UNSET)
 
-        text = d.pop("text")
+        text = d.pop("text", UNSET)
 
         source = d.pop("source")
 
@@ -78,9 +88,9 @@ class AthleteNote:
             id=id,
             type=type,
             date=date,
+            source=source,
             headline=headline,
             text=text,
-            source=source,
         )
 
         athlete_note.additional_properties = d

--- a/spec-gambit.yaml
+++ b/spec-gambit.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: ESPN Gambit API
   version: 1.0.0
-  description: Unofficial ESPN Gambit API for Pick'em challenges and fantasy games. This API is not officially supported by ESPN and may change without notice.
+  description: Unofficial ESPN Gambit API for Pick'em and bracket challenges, including ESPN Tournament Challenge. This API is not officially supported by ESPN and may change without notice.
 
 servers:
   - url: https://gambit-api.fantasy.espn.com
@@ -13,19 +13,24 @@ paths:
     get:
       summary: Get Challenge Details
       description: |
-        Retrieve detailed information about a specific Pick'em challenge.
-        Common challenge names include 'nfl-pigskin-pickem-2025' for NFL Pick'em.
+        Retrieve detailed information about a specific Pick'em or bracket challenge.
+        Verified Tournament Challenge aliases include 'tcmen' and 'tcwomen'.
+        The live API also accepts season-specific keys such as
+        'tournament-challenge-bracket-2026' and
+        'tournament-challenge-bracket-women-2026'.
       operationId: getChallengeDetails
       parameters:
         - name: challengeName
           in: path
           required: true
           description: |
-            The challenge name or key (e.g., 'nfl-pigskin-pickem-2025').
-            Note: UUID-style IDs do not work, use the human-readable name.
+            The challenge name or key (e.g., 'nfl-pigskin-pickem-2025', 'tcmen', or
+            'tournament-challenge-bracket-2026').
+            Note: UUID-style IDs do not work. Use the short alias or the
+            season-specific human-readable key instead.
           schema:
             type: string
-            example: "nfl-pigskin-pickem-2025"
+            example: "tcmen"
         - name: scoringPeriodId
           in: query
           required: false
@@ -58,16 +63,16 @@ paths:
   /apis/v1/challenges/{challengeName}/leaderboard:
     get:
       summary: Get Challenge Leaderboard
-      description: Retrieve the leaderboard for a specific Pick'em challenge
+      description: Retrieve the leaderboard for a specific Pick'em or bracket challenge
       operationId: getChallengeLeaderboard
       parameters:
         - name: challengeName
           in: path
           required: true
-          description: The challenge name (e.g., 'nfl-pigskin-pickem-2025')
+          description: The challenge name or alias (e.g., 'nfl-pigskin-pickem-2025', 'tcmen', or 'tcwomen')
           schema:
             type: string
-            example: "nfl-pigskin-pickem-2025"
+            example: "tcmen"
         - name: view
           in: query
           required: false
@@ -113,10 +118,10 @@ paths:
         - name: challengeName
           in: path
           required: true
-          description: The challenge name
+          description: The challenge name or alias
           schema:
             type: string
-            example: "nfl-pigskin-pickem-2025"
+            example: "tcmen"
         - name: groupId
           in: path
           required: true
@@ -152,10 +157,10 @@ paths:
         - name: challengeName
           in: path
           required: true
-          description: The challenge name
+          description: The challenge name or alias
           schema:
             type: string
-            example: "nfl-pigskin-pickem-2025"
+            example: "tcmen"
         - name: userId
           in: path
           required: true
@@ -185,15 +190,19 @@ paths:
   /apis/v1/propositions:
     get:
       summary: Get Propositions
-      description: Retrieve propositions (picks) for a challenge
+      description: |
+        Retrieve propositions (picks) for a challenge.
+        Note: the live API returns a top-level JSON array of proposition objects,
+        not an envelope object. Use the numeric challenge ID returned by
+        `/apis/v1/challenges/{challengeName}`.
       operationId: getPropositions
       parameters:
         - name: challengeId
           in: query
           required: true
-          description: The challenge ID
+          description: The numeric challenge ID (for example 277 for 2026 men's Tournament Challenge)
           schema:
-            type: string
+            type: integer
         - name: view
           in: query
           required: false
@@ -206,7 +215,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PropositionsResponse'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Proposition'
         '404':
           description: Challenge not found
           content:
@@ -245,11 +256,11 @@ components:
       type: object
       properties:
         id:
-          type: string
+          type: integer
           description: Challenge ID
         key:
           type: string
-          description: Challenge key/name
+          description: Canonical challenge key/name
         name:
           type: string
           description: Display name
@@ -325,7 +336,7 @@ components:
       type: object
       properties:
         challengeId:
-          type: string
+          type: integer
         groupId:
           type: string
           nullable: true
@@ -370,7 +381,7 @@ components:
         name:
           type: string
         challengeId:
-          type: string
+          type: integer
         size:
           type: integer
         settings:
@@ -385,7 +396,7 @@ components:
         userId:
           type: string
         challengeId:
-          type: string
+          type: integer
         groupIds:
           type: array
           items:
@@ -404,7 +415,7 @@ components:
       type: object
       properties:
         challengeId:
-          type: string
+          type: integer
         propositions:
           type: array
           items:

--- a/spec-site-web-api.yaml
+++ b/spec-site-web-api.yaml
@@ -2770,6 +2770,7 @@ components:
               type: string
             jersey:
               type: string
+              description: Optional; omitted for some athletes (e.g. no current jersey)
             position:
               $ref: '#/components/schemas/Position'
             age:
@@ -2802,7 +2803,6 @@ components:
             - lastName
             - displayName
             - fullName
-            - jersey
             - position
             - age
             - displayHeight

--- a/spec-sports-core-api.yaml
+++ b/spec-sports-core-api.yaml
@@ -9640,11 +9640,11 @@ components:
           example: "2025-03-12T15:55Z"
         headline:
           type: string
-          description: Brief summary of the note
+          description: Brief summary of the note (optional; some leagues omit, e.g. MLB season notes)
           example: "Mahomes agreed Wednesday with the Chiefs on a restructure of his contract, Adam Teicher of ESPN.com reports."
         text:
           type: string
-          description: Full text of the note
+          description: Full text of the note (optional when headline/text not returned)
           example: "Mahomes and star defensive tackle Chris Jones both agreed to restructure their contracts Wednesday..."
         source:
           type: string
@@ -9654,8 +9654,6 @@ components:
         - id
         - type
         - date
-        - headline
-        - text
         - source
 
     TeamRecordResponse:

--- a/tests/test_athlete_notes.py
+++ b/tests/test_athlete_notes.py
@@ -1,51 +1,81 @@
 import json
+
 import pytest
-from models.sports_core_api.espn_sports_core_api_client.api.default import get_athlete_season_notes
-from models.sports_core_api.espn_sports_core_api_client.models import AthleteNotesResponse, AthleteNote
+
+from models.sports_core_api.espn_sports_core_api_client.api.default import (
+    get_athlete_season_notes,
+)
+from models.sports_core_api.espn_sports_core_api_client.models import (
+    AthleteNote,
+    AthleteNotesResponse,
+)
 from models.sports_core_api.espn_sports_core_api_client.types import UNSET
 
 
 @pytest.mark.api
-@pytest.mark.parametrize("sport,league,year,athlete_id,expected_min_notes", [
-    ("football", "nfl", "2025", "3139477", 1),  # Patrick Mahomes
-    ("basketball", "nba", "2025", "1966", 1),  # LeBron James
-    ("baseball", "mlb", "2025", "33912", 1),  # Cody Bellinger
-    ("hockey", "nhl", "2025", "3024816", 0),  # Nathan MacKinnon - may have no notes
-])
-def test_get_athlete_season_notes(sports_core_api_client, sport, league, year, athlete_id, expected_min_notes, ensure_json_output_dir):
+@pytest.mark.parametrize(
+    "sport,league,year,athlete_id,expected_min_notes",
+    [
+        ("football", "nfl", "2025", "3139477", 1),  # Patrick Mahomes
+        ("basketball", "nba", "2025", "1966", 1),  # LeBron James
+        ("baseball", "mlb", "2025", "33912", 1),  # Cody Bellinger
+        ("hockey", "nhl", "2025", "3024816", 0),  # Nathan MacKinnon - may have no notes
+    ],
+)
+def test_get_athlete_season_notes(
+    sports_core_api_client,
+    sport,
+    league,
+    year,
+    athlete_id,
+    expected_min_notes,
+    ensure_json_output_dir,
+):
     """Test getting athlete season notes across different sports."""
     response = get_athlete_season_notes.sync_detailed(
         client=sports_core_api_client,
         sport=sport,
         league=league,
         year=year,
-        athlete_id=athlete_id
+        athlete_id=athlete_id,
     )
-    
-    assert response.status_code == 200, f"Expected status code 200, got {response.status_code}"
-    
+
+    assert (
+        response.status_code == 200
+    ), f"Expected status code 200, got {response.status_code}"
+
     result = response.parsed
-    assert isinstance(result, AthleteNotesResponse), "Response should parse to AthleteNotesResponse"
-    
+    assert isinstance(
+        result, AthleteNotesResponse
+    ), "Response should parse to AthleteNotesResponse"
+
     # Validate response structure
-    assert hasattr(result, 'count'), "Response should have count"
-    assert hasattr(result, 'page_index'), "Response should have page_index"
-    assert hasattr(result, 'page_size'), "Response should have page_size"
-    assert hasattr(result, 'page_count'), "Response should have page_count"
-    assert hasattr(result, 'items'), "Response should have items"
-    
+    assert hasattr(result, "count"), "Response should have count"
+    assert hasattr(result, "page_index"), "Response should have page_index"
+    assert hasattr(result, "page_size"), "Response should have page_size"
+    assert hasattr(result, "page_count"), "Response should have page_count"
+    assert hasattr(result, "items"), "Response should have items"
+
     # Validate pagination
     if result.count > 0:
-        assert result.page_index >= 1, "Page index should be at least 1 when there are results"
+        assert (
+            result.page_index >= 1
+        ), "Page index should be at least 1 when there are results"
     else:
-        assert result.page_index >= 0, "Page index should be non-negative when there are no results"
+        assert (
+            result.page_index >= 0
+        ), "Page index should be non-negative when there are no results"
     assert result.page_size > 0, "Page size should be positive"
     assert result.page_count >= 0, "Page count should be non-negative"
-    
+
     # Validate notes
-    assert result.count >= expected_min_notes, f"Expected at least {expected_min_notes} notes, got {result.count}"
-    assert len(result.items) == min(result.count, result.page_size), "Items length should match count or page size"
-    
+    assert (
+        result.count >= expected_min_notes
+    ), f"Expected at least {expected_min_notes} notes, got {result.count}"
+    assert len(result.items) == min(
+        result.count, result.page_size
+    ), "Items length should match count or page size"
+
     # Validate each note
     for note in result.items:
         assert isinstance(note, AthleteNote), "Each item should be an AthleteNote"
@@ -58,12 +88,17 @@ def test_get_athlete_season_notes(sports_core_api_client, sport, league, year, a
         if note.text is not UNSET:
             assert isinstance(note.text, str)
         assert note.source, "Note should have a source"
-    
+
     # Save response for analysis
-    with open(f"{ensure_json_output_dir}/athlete_notes_{sport}_{athlete_id}_{year}_test.json", "w") as f:
+    with open(
+        f"{ensure_json_output_dir}/athlete_notes_{sport}_{athlete_id}_{year}_test.json",
+        "w",
+    ) as f:
         json.dump(result.to_dict(), f, indent=2)
-    
-    print(f"✓ {sport.upper()} athlete {athlete_id} has {result.count} notes for {year} season")
+
+    print(
+        f"✓ {sport.upper()} athlete {athlete_id} has {result.count} notes for {year} season"
+    )
 
 
 @pytest.mark.api
@@ -74,33 +109,40 @@ def test_get_athlete_season_notes_invalid_athlete(sports_core_api_client):
         sport="football",
         league="nfl",
         year="2025",
-        athlete_id="99999999"  # Invalid athlete ID
+        athlete_id="99999999",  # Invalid athlete ID
     )
-    
+
     # The API may return 200 with empty results or 404
-    assert response.status_code in [200, 404], f"Expected status code 200 or 404, got {response.status_code}"
-    
+    assert response.status_code in [
+        200,
+        404,
+    ], f"Expected status code 200 or 404, got {response.status_code}"
+
     if response.status_code == 200:
         result = response.parsed
         assert result.count == 0, "Invalid athlete should have no notes"
         assert len(result.items) == 0, "Invalid athlete should have empty items list"
 
 
-@pytest.mark.api 
+@pytest.mark.api
 def test_get_athlete_season_notes_past_year(sports_core_api_client):
     """Test getting notes for past year."""
     response = get_athlete_season_notes.sync_detailed(
         client=sports_core_api_client,
         sport="football",
-        league="nfl", 
+        league="nfl",
         year="2023",  # Past year
-        athlete_id="3139477"
+        athlete_id="3139477",
     )
-    
-    assert response.status_code == 200, f"Expected status code 200, got {response.status_code}"
-    
+
+    assert (
+        response.status_code == 200
+    ), f"Expected status code 200, got {response.status_code}"
+
     result = response.parsed
-    assert isinstance(result, AthleteNotesResponse), "Response should parse to AthleteNotesResponse"
+    assert isinstance(
+        result, AthleteNotesResponse
+    ), "Response should parse to AthleteNotesResponse"
     # Past years may or may not have notes, just validate the structure
-    assert hasattr(result, 'count'), "Response should have count"
-    assert hasattr(result, 'items'), "Response should have items"
+    assert hasattr(result, "count"), "Response should have count"
+    assert hasattr(result, "items"), "Response should have items"

--- a/tests/test_athlete_notes.py
+++ b/tests/test_athlete_notes.py
@@ -2,6 +2,7 @@ import json
 import pytest
 from models.sports_core_api.espn_sports_core_api_client.api.default import get_athlete_season_notes
 from models.sports_core_api.espn_sports_core_api_client.models import AthleteNotesResponse, AthleteNote
+from models.sports_core_api.espn_sports_core_api_client.types import UNSET
 
 
 @pytest.mark.api
@@ -51,8 +52,11 @@ def test_get_athlete_season_notes(sports_core_api_client, sport, league, year, a
         assert note.id, "Note should have an ID"
         assert note.type, "Note should have a type"
         assert note.date, "Note should have a date"
-        assert note.headline, "Note should have a headline"
-        assert note.text, "Note should have text"
+        # Some leagues (e.g. MLB) omit headline/text on season notes
+        if note.headline is not UNSET:
+            assert isinstance(note.headline, str)
+        if note.text is not UNSET:
+            assert isinstance(note.text, str)
         assert note.source, "Note should have a source"
     
     # Save response for analysis

--- a/tests/test_gambit_challenges.py
+++ b/tests/test_gambit_challenges.py
@@ -1,15 +1,17 @@
-import pytest
 import json
 import logging
+
+import pytest
+
 from models.gambit_api.espn_gambit_api_client.api.default import (
     get_challenge_details,
-    get_challenge_leaderboard
+    get_challenge_leaderboard,
 )
 from models.gambit_api.espn_gambit_api_client.models import (
     ChallengeResponse,
-    LeaderboardResponse,
     GetChallengeDetailsView,
-    GetChallengeLeaderboardView
+    GetChallengeLeaderboardView,
+    LeaderboardResponse,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -18,36 +20,42 @@ logging.basicConfig(level=logging.INFO)
 @pytest.mark.api
 def test_get_challenge_details(gambit_api_client, ensure_json_output_dir):
     """Test fetching NFL Pick'em challenge details."""
-    
+
     # Fetch challenge details for 2025 NFL Pick'em
     response = get_challenge_details.sync_detailed(
         client=gambit_api_client,
         challenge_name="nfl-pigskin-pickem-2025",
         scoring_period_id=1,
-        view=GetChallengeDetailsView.PICKS
+        view=GetChallengeDetailsView.PICKS,
     )
-    
-    assert response.status_code == 200, f"Expected status code 200, got {response.status_code}"
-    
+
+    assert (
+        response.status_code == 200
+    ), f"Expected status code 200, got {response.status_code}"
+
     result = response.parsed
-    assert isinstance(result, ChallengeResponse), "Response should parse to ChallengeResponse"
-    
+    assert isinstance(
+        result, ChallengeResponse
+    ), "Response should parse to ChallengeResponse"
+
     # Check challenge properties
     assert result.key == "nfl-pigskin-pickem-2025", "Challenge key should match"
     assert result.name, "Challenge should have a name"
     assert result.active is not None, "Challenge should have active status"
-    
+
     logging.info(f"Challenge: {result.name}")
     logging.info(f"Active: {result.active}")
     logging.info(f"Current scoring period: {result.current_scoring_period}")
     logging.info(f"State: {result.state}")
-    
+
     # Check propositions if available
     if result.propositions:
         logging.info(f"Number of propositions: {len(result.propositions)}")
         first_prop = result.propositions[0]
-        logging.info(f"First proposition: {first_prop.text if first_prop.text else 'No text'}")
-    
+        logging.info(
+            f"First proposition: {first_prop.text if first_prop.text else 'No text'}"
+        )
+
     # Save a sample of the challenge data
     sample_data = {
         "id": result.id,
@@ -58,66 +66,74 @@ def test_get_challenge_details(gambit_api_client, ensure_json_output_dir):
         "current_scoring_period": result.current_scoring_period,
         "start_date": result.start_date,
         "end_date": result.end_date,
-        "proposition_count": len(result.propositions) if result.propositions else 0
+        "proposition_count": len(result.propositions) if result.propositions else 0,
     }
-    
-    with open(f"{ensure_json_output_dir}/gambit_challenge_details_sample.json", "w") as f:
+
+    with open(
+        f"{ensure_json_output_dir}/gambit_challenge_details_sample.json", "w"
+    ) as f:
         json.dump(sample_data, f, indent=2)
 
 
 @pytest.mark.api
 def test_get_challenge_leaderboard(gambit_api_client, ensure_json_output_dir):
     """Test fetching NFL Pick'em challenge leaderboard."""
-    
+
     # Fetch leaderboard for 2025 NFL Pick'em
     response = get_challenge_leaderboard.sync_detailed(
         client=gambit_api_client,
         challenge_name="nfl-pigskin-pickem-2025",
         view=GetChallengeLeaderboardView.RANKS,
-        limit=10  # Get top 10 entries
+        limit=10,  # Get top 10 entries
     )
-    
-    assert response.status_code == 200, f"Expected status code 200, got {response.status_code}"
-    
+
+    assert (
+        response.status_code == 200
+    ), f"Expected status code 200, got {response.status_code}"
+
     result = response.parsed
-    assert isinstance(result, LeaderboardResponse), "Response should parse to LeaderboardResponse"
-    
+    assert isinstance(
+        result, LeaderboardResponse
+    ), "Response should parse to LeaderboardResponse"
+
     # Check leaderboard properties
     assert result.challenge_id, "Should have challenge ID"
     assert result.size is not None, "Should have size"
     assert result.entries is not None, "Should have entries"
-    
+
     logging.info(f"Challenge ID: {result.challenge_id}")
     logging.info(f"Total entries: {result.size}")
     logging.info(f"Entries returned: {len(result.entries) if result.entries else 0}")
-    
+
     # Log top entries
     if result.entries:
         logging.info("\nTop entries:")
         for i, entry in enumerate(result.entries[:5], 1):
-            logging.info(f"{i}. {entry.display_name if entry.display_name else 'Unknown'} - "
-                        f"Score: {entry.score}, Rank: {entry.rank}")
-    
+            logging.info(
+                f"{i}. {entry.display_name if entry.display_name else 'Unknown'} - "
+                f"Score: {entry.score}, Rank: {entry.rank}"
+            )
+
     # Save leaderboard sample
     sample_data = {
         "challenge_id": result.challenge_id,
         "total_entries": result.size,
         "locked": result.locked,
-        "top_entries": [entry.to_dict() for entry in (result.entries or [])[:10]]
+        "top_entries": [entry.to_dict() for entry in (result.entries or [])[:10]],
     }
-    
+
     with open(f"{ensure_json_output_dir}/gambit_leaderboard_sample.json", "w") as f:
         json.dump(sample_data, f, indent=2)
 
 
 @pytest.mark.api
-@pytest.mark.xfail(reason="Challenge name with year might vary")
 def test_challenge_not_found(gambit_api_client):
     """Test handling of non-existent challenge."""
-    
+
     response = get_challenge_details.sync_detailed(
-        client=gambit_api_client,
-        challenge_name="non-existent-challenge-2025"
+        client=gambit_api_client, challenge_name="non-existent-challenge-2025"
     )
-    
-    assert response.status_code == 404, f"Expected status code 404, got {response.status_code}"
+
+    assert (
+        response.status_code == 404
+    ), f"Expected status code 404, got {response.status_code}"

--- a/tests/test_gambit_tournament_challenge.py
+++ b/tests/test_gambit_tournament_challenge.py
@@ -1,0 +1,144 @@
+import json
+
+import pytest
+
+from models.gambit_api.espn_gambit_api_client.api.default import (
+    get_challenge_details,
+    get_challenge_leaderboard,
+    get_propositions,
+)
+from models.gambit_api.espn_gambit_api_client.models import (
+    ChallengeResponse,
+    GetChallengeDetailsView,
+    GetChallengeLeaderboardView,
+    LeaderboardResponse,
+    Proposition,
+)
+
+
+def get_mapping_value(mappings, mapping_type):
+    for mapping in mappings:
+        if mapping.get("type") == mapping_type:
+            return mapping.get("value")
+    return None
+
+
+@pytest.mark.api
+def test_get_mens_tournament_challenge_details(
+    gambit_api_client, ensure_json_output_dir
+):
+    response = get_challenge_details.sync_detailed(
+        client=gambit_api_client,
+        challenge_name="tcmen",
+        view=GetChallengeDetailsView.DETAILS,
+    )
+
+    assert response.status_code == 200, (
+        f"Expected status code 200, got {response.status_code}"
+    )
+
+    result = response.parsed
+    assert isinstance(result, ChallengeResponse)
+    assert result.key.startswith("tournament-challenge-bracket-")
+    assert result.active is True
+    assert result["gameType"] == "BRACKET"
+
+    mappings = result["mappings"]
+    assert get_mapping_value(mappings, "LEAGUE") == "mens-college-basketball"
+    assert result["featuredGroupIds"], "Challenge should expose featured group IDs"
+
+    sample_data = {
+        "alias": "tcmen",
+        "canonical_key": result.key,
+        "challenge_id": result.id,
+        "game_id": result.game_id,
+        "game_type": result["gameType"],
+        "league": get_mapping_value(mappings, "LEAGUE"),
+    }
+
+    with open(
+        f"{ensure_json_output_dir}/gambit_tournament_challenge_details_sample.json",
+        "w",
+    ) as f:
+        json.dump(sample_data, f, indent=2)
+
+
+@pytest.mark.api
+def test_get_womens_tournament_challenge_alias_and_leaderboard(gambit_api_client):
+    details_response = get_challenge_details.sync_detailed(
+        client=gambit_api_client,
+        challenge_name="tcwomen",
+        view=GetChallengeDetailsView.DETAILS,
+    )
+
+    assert details_response.status_code == 200, (
+        f"Expected status code 200, got {details_response.status_code}"
+    )
+
+    details = details_response.parsed
+    assert isinstance(details, ChallengeResponse)
+    assert details.key.startswith("tournament-challenge-bracket-women-")
+
+    canonical_response = get_challenge_details.sync_detailed(
+        client=gambit_api_client,
+        challenge_name=details.key,
+        view=GetChallengeDetailsView.DETAILS,
+    )
+
+    assert canonical_response.status_code == 200, (
+        f"Expected status code 200, got {canonical_response.status_code}"
+    )
+
+    canonical = canonical_response.parsed
+    assert isinstance(canonical, ChallengeResponse)
+    assert canonical.id == details.id
+
+    leaderboard_response = get_challenge_leaderboard.sync_detailed(
+        client=gambit_api_client,
+        challenge_name="tcwomen",
+        view=GetChallengeLeaderboardView.RANKS,
+        limit=5,
+    )
+
+    assert leaderboard_response.status_code == 200, (
+        f"Expected status code 200, got {leaderboard_response.status_code}"
+    )
+
+    leaderboard = leaderboard_response.parsed
+    assert isinstance(leaderboard, LeaderboardResponse)
+    assert leaderboard.challenge_id == details.id
+    assert leaderboard.entries, "Leaderboard should include entries"
+    assert leaderboard.entries[0]["member"], "Entries should include member data"
+
+
+@pytest.mark.api
+def test_get_tournament_challenge_propositions(gambit_api_client):
+    details_response = get_challenge_details.sync_detailed(
+        client=gambit_api_client,
+        challenge_name="tcmen",
+        view=GetChallengeDetailsView.DETAILS,
+    )
+
+    assert details_response.status_code == 200, (
+        f"Expected status code 200, got {details_response.status_code}"
+    )
+
+    details = details_response.parsed
+    assert isinstance(details, ChallengeResponse)
+
+    response = get_propositions.sync_detailed(
+        client=gambit_api_client,
+        challenge_id=details.id,
+    )
+
+    assert response.status_code == 200, (
+        f"Expected status code 200, got {response.status_code}"
+    )
+
+    result = response.parsed
+    assert isinstance(result, list)
+    assert result, "Propositions response should include matchup propositions"
+    assert isinstance(result[0], Proposition)
+    assert result[0]["challengeId"] == details.id
+    assert get_mapping_value(result[0]["mappings"], "COMPETITION_ID")
+    assert result[0]["possibleOutcomes"], "Proposition should include bracket outcomes"

--- a/tests/test_gambit_tournament_challenge.py
+++ b/tests/test_gambit_tournament_challenge.py
@@ -33,9 +33,9 @@ def test_get_mens_tournament_challenge_details(
         view=GetChallengeDetailsView.DETAILS,
     )
 
-    assert response.status_code == 200, (
-        f"Expected status code 200, got {response.status_code}"
-    )
+    assert (
+        response.status_code == 200
+    ), f"Expected status code 200, got {response.status_code}"
 
     result = response.parsed
     assert isinstance(result, ChallengeResponse)
@@ -71,9 +71,9 @@ def test_get_womens_tournament_challenge_alias_and_leaderboard(gambit_api_client
         view=GetChallengeDetailsView.DETAILS,
     )
 
-    assert details_response.status_code == 200, (
-        f"Expected status code 200, got {details_response.status_code}"
-    )
+    assert (
+        details_response.status_code == 200
+    ), f"Expected status code 200, got {details_response.status_code}"
 
     details = details_response.parsed
     assert isinstance(details, ChallengeResponse)
@@ -85,9 +85,9 @@ def test_get_womens_tournament_challenge_alias_and_leaderboard(gambit_api_client
         view=GetChallengeDetailsView.DETAILS,
     )
 
-    assert canonical_response.status_code == 200, (
-        f"Expected status code 200, got {canonical_response.status_code}"
-    )
+    assert (
+        canonical_response.status_code == 200
+    ), f"Expected status code 200, got {canonical_response.status_code}"
 
     canonical = canonical_response.parsed
     assert isinstance(canonical, ChallengeResponse)
@@ -100,9 +100,9 @@ def test_get_womens_tournament_challenge_alias_and_leaderboard(gambit_api_client
         limit=5,
     )
 
-    assert leaderboard_response.status_code == 200, (
-        f"Expected status code 200, got {leaderboard_response.status_code}"
-    )
+    assert (
+        leaderboard_response.status_code == 200
+    ), f"Expected status code 200, got {leaderboard_response.status_code}"
 
     leaderboard = leaderboard_response.parsed
     assert isinstance(leaderboard, LeaderboardResponse)
@@ -119,9 +119,9 @@ def test_get_tournament_challenge_propositions(gambit_api_client):
         view=GetChallengeDetailsView.DETAILS,
     )
 
-    assert details_response.status_code == 200, (
-        f"Expected status code 200, got {details_response.status_code}"
-    )
+    assert (
+        details_response.status_code == 200
+    ), f"Expected status code 200, got {details_response.status_code}"
 
     details = details_response.parsed
     assert isinstance(details, ChallengeResponse)
@@ -131,9 +131,9 @@ def test_get_tournament_challenge_propositions(gambit_api_client):
         challenge_id=details.id,
     )
 
-    assert response.status_code == 200, (
-        f"Expected status code 200, got {response.status_code}"
-    )
+    assert (
+        response.status_code == 200
+    ), f"Expected status code 200, got {response.status_code}"
 
     result = response.parsed
     assert isinstance(result, list)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## Summary
- document the verified ESPN Tournament Challenge aliases, canonical keys, IDs, and working Gambit endpoint patterns in `TOURNAMENT_CHALLENGE.md`
- update `spec-gambit.yaml` to mention Tournament Challenge aliases and to model `/apis/v1/propositions` as the live top-level proposition array
- regenerate the Gambit client and add live tests covering men's and women's Tournament Challenge details, leaderboard access, and propositions
- remove the stale `xfail` on the Gambit 404 test now that it passes consistently
- fix integration-test failures caused by live schema drift by making athlete note `headline`/`text` optional and athlete profile `jersey` optional
- relax the athlete notes test so MLB season notes can pass when ESPN omits `headline` and `text`

## Testing
- `uv run pytest tests/test_gambit_challenges.py tests/test_gambit_tournament_challenge.py -v`
- `uv run ruff check models/gambit_api tests/test_gambit_challenges.py tests/test_gambit_tournament_challenge.py`
- `uv run black --check models/gambit_api tests/test_gambit_challenges.py tests/test_gambit_tournament_challenge.py`
- `uv run isort --check models/gambit_api tests/test_gambit_challenges.py tests/test_gambit_tournament_challenge.py`
- `uv run pytest tests/test_athlete_notes.py tests/test_site_web_api.py -v -n0`
- `uv run ruff check models/site_web_api/espn_site_web_api_client/models/athlete_profile_response_athlete.py models/sports_core_api/espn_sports_core_api_client/models/athlete_note.py tests/test_athlete_notes.py`
- `uv run black --check models/site_web_api/espn_site_web_api_client/models/athlete_profile_response_athlete.py models/sports_core_api/espn_sports_core_api_client/models/athlete_note.py tests/test_athlete_notes.py`
- `uv run isort --check models/site_web_api/espn_site_web_api_client/models/athlete_profile_response_athlete.py models/sports_core_api/espn_sports_core_api_client/models/athlete_note.py tests/test_athlete_notes.py`
- `gh run watch 23209611550 --exit-status`

## Notes
- the latest `Integration Tests` GitHub Actions run on this branch completed successfully after the fix
- GitHub Actions still shows external cache/service warnings and a Node 20 deprecation annotation, but the job passes
- repo-wide `black --check .` and `isort --check .` still report broad pre-existing generated-code formatting drift outside this diff; the changed surfaces pass targeted checks

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36368e0b-187d-480b-948a-111faed249d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36368e0b-187d-480b-948a-111faed249d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

