### PR TITLE
aweldy/add-joke-to-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 
 The goal of this project is to provide a collection of OpenAPI specs for the various ESPN APIs with full type definitions for the responses. This will allow developers to generate clients in any language to interact with the API, generally to fetch real-time or historical sports data.
 
+## Joke of the README
+
+Why did the OpenAPI spec take up sports broadcasting?
+It was already great at describing every play — endpoint by endpoint.
+
 ## Project Structure
 
 The core of this project is the `spec-*.yaml` files. These contain both the endpoint definitions & the models used in the responses. I've tried to generalize them as much as I can, and provide enums where there's a human-friendly typed list (e.g. the list of sports).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small joke to the README, just under the project description.

## Why

Levity. The README was all business — now it has one (1) joke.

## Changes

- `README.md`: new "Joke of the README" section with a single OpenAPI/sports-flavored joke.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eaf00050-03fa-4e4e-baec-545f7a65d827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eaf00050-03fa-4e4e-baec-545f7a65d827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

