### PR TITLE
Adapt e2e tests to live ESPN API schema/behavior changes

### DIFF
--- a/models/site_api/espn_nfl_api_client/models/news_category_type.py
+++ b/models/site_api/espn_nfl_api_client/models/news_category_type.py
@@ -8,6 +8,8 @@ class NewsCategoryType(str, Enum):
     EVENT = "event"
     GUID = "guid"
     LEAGUE = "league"
+    PODCAST = "podcast"
+    SERIES = "series"
     TEAM = "team"
     TOPIC = "topic"
 

--- a/models/site_api/espn_nfl_api_client/models/news_contributor.py
+++ b/models/site_api/espn_nfl_api_client/models/news_contributor.py
@@ -1,7 +1,9 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.news_contributor_links import NewsContributorLinks
@@ -16,12 +18,12 @@ class NewsContributor:
     Attributes:
         id (int): Contributor identifier Example: 2078.
         description (str): Contributor name Example: Jamison Hensley.
-        links (NewsContributorLinks):
+        links (Union[Unset, NewsContributorLinks]):
     """
 
     id: int
     description: str
-    links: "NewsContributorLinks"
+    links: Union[Unset, "NewsContributorLinks"] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -29,7 +31,9 @@ class NewsContributor:
 
         description = self.description
 
-        links = self.links.to_dict()
+        links: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.links, Unset):
+            links = self.links.to_dict()
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -37,9 +41,10 @@ class NewsContributor:
             {
                 "id": id,
                 "description": description,
-                "links": links,
             }
         )
+        if links is not UNSET:
+            field_dict["links"] = links
 
         return field_dict
 
@@ -52,7 +57,12 @@ class NewsContributor:
 
         description = d.pop("description")
 
-        links = NewsContributorLinks.from_dict(d.pop("links"))
+        _links = d.pop("links", UNSET)
+        links: Union[Unset, NewsContributorLinks]
+        if isinstance(_links, Unset):
+            links = UNSET
+        else:
+            links = NewsContributorLinks.from_dict(_links)
 
         news_contributor = cls(
             id=id,

--- a/models/site_api/espn_nfl_api_client/models/soccer_standings_response.py
+++ b/models/site_api/espn_nfl_api_client/models/soccer_standings_response.py
@@ -21,7 +21,8 @@ class SoccerStandingsResponse:
         id (str): League ID Example: 23.
         name (str): League name Example: English Premier League.
         abbreviation (str): League abbreviation Example: ENG.
-        children (List['SoccerStandingsGroup']): Array of standings groups (e.g., overall standings, group standings)
+        children (Union[Unset, List['SoccerStandingsGroup']]): Array of standings groups (e.g., overall standings, group
+            standings)
         uid (Union[Unset, str]): Unique identifier for the standings Example: s:600~l:23.
         seasons (Union[Unset, List['SeasonReference']]): Available seasons
     """
@@ -29,7 +30,7 @@ class SoccerStandingsResponse:
     id: str
     name: str
     abbreviation: str
-    children: List["SoccerStandingsGroup"]
+    children: Union[Unset, List["SoccerStandingsGroup"]] = UNSET
     uid: Union[Unset, str] = UNSET
     seasons: Union[Unset, List["SeasonReference"]] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -41,10 +42,12 @@ class SoccerStandingsResponse:
 
         abbreviation = self.abbreviation
 
-        children = []
-        for children_item_data in self.children:
-            children_item = children_item_data.to_dict()
-            children.append(children_item)
+        children: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.children, Unset):
+            children = []
+            for children_item_data in self.children:
+                children_item = children_item_data.to_dict()
+                children.append(children_item)
 
         uid = self.uid
 
@@ -62,9 +65,10 @@ class SoccerStandingsResponse:
                 "id": id,
                 "name": name,
                 "abbreviation": abbreviation,
-                "children": children,
             }
         )
+        if children is not UNSET:
+            field_dict["children"] = children
         if uid is not UNSET:
             field_dict["uid"] = uid
         if seasons is not UNSET:
@@ -85,8 +89,8 @@ class SoccerStandingsResponse:
         abbreviation = d.pop("abbreviation")
 
         children = []
-        _children = d.pop("children")
-        for children_item_data in _children:
+        _children = d.pop("children", UNSET)
+        for children_item_data in _children or []:
             children_item = SoccerStandingsGroup.from_dict(children_item_data)
 
             children.append(children_item)

--- a/models/site_web_api/espn_site_web_api_client/models/mlb_athlete_details_response.py
+++ b/models/site_web_api/espn_site_web_api_client/models/mlb_athlete_details_response.py
@@ -1,7 +1,9 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.link import Link
@@ -28,8 +30,8 @@ class MLBAthleteDetailsResponse:
         player_switcher (MLBAthleteDetailsResponsePlayerSwitcher):
         quicklinks (List['MLBAthleteDetailsResponseQuicklinksItem']):
         links (List['Link']):
-        tickets_info (MLBAthleteDetailsResponseTicketsInfo):
-        standings (MLBAthleteDetailsResponseStandings):
+        tickets_info (Union[Unset, MLBAthleteDetailsResponseTicketsInfo]):
+        standings (Union[Unset, MLBAthleteDetailsResponseStandings]):
     """
 
     athlete: "MLBAthleteDetailsAthlete"
@@ -38,8 +40,8 @@ class MLBAthleteDetailsResponse:
     player_switcher: "MLBAthleteDetailsResponsePlayerSwitcher"
     quicklinks: List["MLBAthleteDetailsResponseQuicklinksItem"]
     links: List["Link"]
-    tickets_info: "MLBAthleteDetailsResponseTicketsInfo"
-    standings: "MLBAthleteDetailsResponseStandings"
+    tickets_info: Union[Unset, "MLBAthleteDetailsResponseTicketsInfo"] = UNSET
+    standings: Union[Unset, "MLBAthleteDetailsResponseStandings"] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -61,9 +63,13 @@ class MLBAthleteDetailsResponse:
             links_item = links_item_data.to_dict()
             links.append(links_item)
 
-        tickets_info = self.tickets_info.to_dict()
+        tickets_info: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.tickets_info, Unset):
+            tickets_info = self.tickets_info.to_dict()
 
-        standings = self.standings.to_dict()
+        standings: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.standings, Unset):
+            standings = self.standings.to_dict()
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -75,10 +81,12 @@ class MLBAthleteDetailsResponse:
                 "playerSwitcher": player_switcher,
                 "quicklinks": quicklinks,
                 "links": links,
-                "ticketsInfo": tickets_info,
-                "standings": standings,
             }
         )
+        if tickets_info is not UNSET:
+            field_dict["ticketsInfo"] = tickets_info
+        if standings is not UNSET:
+            field_dict["standings"] = standings
 
         return field_dict
 
@@ -116,9 +124,19 @@ class MLBAthleteDetailsResponse:
 
             links.append(links_item)
 
-        tickets_info = MLBAthleteDetailsResponseTicketsInfo.from_dict(d.pop("ticketsInfo"))
+        _tickets_info = d.pop("ticketsInfo", UNSET)
+        tickets_info: Union[Unset, MLBAthleteDetailsResponseTicketsInfo]
+        if isinstance(_tickets_info, Unset):
+            tickets_info = UNSET
+        else:
+            tickets_info = MLBAthleteDetailsResponseTicketsInfo.from_dict(_tickets_info)
 
-        standings = MLBAthleteDetailsResponseStandings.from_dict(d.pop("standings"))
+        _standings = d.pop("standings", UNSET)
+        standings: Union[Unset, MLBAthleteDetailsResponseStandings]
+        if isinstance(_standings, Unset):
+            standings = UNSET
+        else:
+            standings = MLBAthleteDetailsResponseStandings.from_dict(_standings)
 
         mlb_athlete_details_response = cls(
             athlete=athlete,

--- a/spec-site-api.yaml
+++ b/spec-site-api.yaml
@@ -2622,7 +2622,7 @@ components:
           type: string
           description: Type of category
           example: "topic"
-          enum: ["topic", "athlete", "team", "contributor", "league", "guid", "editorialindicator"]
+          enum: ["topic", "athlete", "team", "contributor", "league", "guid", "editorialindicator", "podcast", "series"]
         guid:
           type: string
           format: uuid
@@ -2969,7 +2969,7 @@ components:
           type: string
           description: Type of category
           example: "topic"
-          enum: ["topic", "athlete", "team", "contributor", "league", "guid", "editorialindicator"]
+          enum: ["topic", "athlete", "team", "contributor", "league", "guid", "editorialindicator", "podcast", "series"]
         guid:
           type: string
           format: uuid
@@ -3085,7 +3085,6 @@ components:
       required:
         - id
         - description
-        - links
 
     NewsTeam:
       type: object
@@ -5398,7 +5397,6 @@ components:
         - id
         - name
         - abbreviation
-        - children
       properties:
         uid:
           type: string

--- a/spec-site-web-api.yaml
+++ b/spec-site-web-api.yaml
@@ -2926,8 +2926,6 @@ components:
         - playerSwitcher
         - quicklinks
         - season
-        - standings
-        - ticketsInfo
       properties:
         athlete:
           $ref: '#/components/schemas/MLBAthleteDetailsAthlete'

--- a/tests/test_gambit_tournament_challenge.py
+++ b/tests/test_gambit_tournament_challenge.py
@@ -40,7 +40,9 @@ def test_get_mens_tournament_challenge_details(
     result = response.parsed
     assert isinstance(result, ChallengeResponse)
     assert result.key.startswith("tournament-challenge-bracket-")
-    assert result.active is True
+    # `active` reflects whether the tournament is currently running, which varies
+    # by season (it is False once the bracket is complete in the offseason).
+    assert isinstance(result.active, bool)
     assert result["gameType"] == "BRACKET"
 
     mappings = result["mappings"]

--- a/tests/test_soccer_standings.py
+++ b/tests/test_soccer_standings.py
@@ -25,10 +25,19 @@ def validate_soccer_standings_response(data: SoccerStandingsResponse) -> None:
     assert data.id, "Missing id in response"
     assert data.name, "Missing name in response"
     assert data.abbreviation, "Missing abbreviation in response"
-    assert data.children, "Missing children in response"
-    
+
     logger.info(f"League: {data.name} ({data.abbreviation})")
-    
+
+    # `children` (standings groups) may be empty when a league is between
+    # seasons (e.g. the new season has not started yet, so no standings exist).
+    # Treat this as a valid response and skip the per-group validation below.
+    if not data.children:
+        logger.info(
+            f"No standings groups available for {data.name}; "
+            "league is likely between seasons"
+        )
+        return
+
     # Check children (standings groups)
     assert len(data.children) > 0, "Expected at least one standings group"
     logger.info(f"Found {len(data.children)} standings groups")


### PR DESCRIPTION
## Summary

Running the end-to-end suite against the live ESPN APIs surfaced **20 failures** caused by upstream API shape/behavior changes. This PR updates the generated clients (and their source OpenAPI specs) to make newly-optional fields optional, and relaxes a couple of season-dependent assertions so the tests reflect the current API.

## Changes

- **News contributor `links` now optional** — contributors are returned with only `id`/`description`. Fixes `KeyError: 'links'` across NFL/MLB/NHL/NBA/college/soccer news endpoints (`test_news`, `test_site_api_news`, `test_soccer_news`, `test_generic_endpoints`).
- **`NewsCategoryType` gains `podcast` and `series`** — new category types now returned by the news API (`test_all_endpoints_for_nba`/`wnba`).
- **`SoccerStandingsResponse.children` now optional** — and the soccer standings test tolerates an empty standings group when a league is between seasons (e.g. Ligue 1 in the offseason).
- **`MLBAthleteDetailsResponse.ticketsInfo` and `standings` now optional** — the MLB athlete profile response no longer always includes them (`test_get_athlete_profile_mlb`).
- **Gambit men's tournament challenge** — assert `active` is a `bool` rather than always `True`, since the bracket is inactive once the tournament is complete.

Spec YAML (`spec-site-api.yaml`, `spec-site-web-api.yaml`) updated to match so the source of truth stays accurate. Following the repo's established convention, the generated models were edited in place rather than fully regenerated (regeneration would revert prior manual schema fixes).

## Testing

`uv run pytest` → **619 passed, 14 skipped, 7 xfailed, 3 xpassed** (previously 20 failed).

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/aaronweldy/espn-openapi/task_m72exmvjbktz3g9c)