### PR TITLE
[integration tests] adapt to live ESPN API schema/behavior changes

### DIFF
--- a/models/site_api/espn_nfl_api_client/models/news_category_type.py
+++ b/models/site_api/espn_nfl_api_client/models/news_category_type.py
@@ -8,6 +8,7 @@ class NewsCategoryType(str, Enum):
     EVENT = "event"
     GUID = "guid"
     LEAGUE = "league"
+    SERIES = "series"
     TEAM = "team"
     TOPIC = "topic"
 

--- a/models/site_api/espn_nfl_api_client/models/news_contributor.py
+++ b/models/site_api/espn_nfl_api_client/models/news_contributor.py
@@ -1,7 +1,9 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.news_contributor_links import NewsContributorLinks
@@ -16,12 +18,12 @@ class NewsContributor:
     Attributes:
         id (int): Contributor identifier Example: 2078.
         description (str): Contributor name Example: Jamison Hensley.
-        links (NewsContributorLinks):
+        links (Union[Unset, NewsContributorLinks]):
     """
 
     id: int
     description: str
-    links: "NewsContributorLinks"
+    links: Union[Unset, "NewsContributorLinks"] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -29,7 +31,9 @@ class NewsContributor:
 
         description = self.description
 
-        links = self.links.to_dict()
+        links: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.links, Unset):
+            links = self.links.to_dict()
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -37,9 +41,10 @@ class NewsContributor:
             {
                 "id": id,
                 "description": description,
-                "links": links,
             }
         )
+        if links is not UNSET:
+            field_dict["links"] = links
 
         return field_dict
 
@@ -52,7 +57,12 @@ class NewsContributor:
 
         description = d.pop("description")
 
-        links = NewsContributorLinks.from_dict(d.pop("links"))
+        _links = d.pop("links", UNSET)
+        links: Union[Unset, NewsContributorLinks]
+        if isinstance(_links, Unset):
+            links = UNSET
+        else:
+            links = NewsContributorLinks.from_dict(_links)
 
         news_contributor = cls(
             id=id,

--- a/models/site_api/espn_nfl_api_client/models/soccer_standings_response.py
+++ b/models/site_api/espn_nfl_api_client/models/soccer_standings_response.py
@@ -21,7 +21,8 @@ class SoccerStandingsResponse:
         id (str): League ID Example: 23.
         name (str): League name Example: English Premier League.
         abbreviation (str): League abbreviation Example: ENG.
-        children (List['SoccerStandingsGroup']): Array of standings groups (e.g., overall standings, group standings)
+        children (Union[Unset, List['SoccerStandingsGroup']]): Array of standings groups (e.g., overall standings,
+            group standings). May be omitted when the league is between seasons and standings are not yet available.
         uid (Union[Unset, str]): Unique identifier for the standings Example: s:600~l:23.
         seasons (Union[Unset, List['SeasonReference']]): Available seasons
     """
@@ -29,7 +30,7 @@ class SoccerStandingsResponse:
     id: str
     name: str
     abbreviation: str
-    children: List["SoccerStandingsGroup"]
+    children: Union[Unset, List["SoccerStandingsGroup"]] = UNSET
     uid: Union[Unset, str] = UNSET
     seasons: Union[Unset, List["SeasonReference"]] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -41,10 +42,12 @@ class SoccerStandingsResponse:
 
         abbreviation = self.abbreviation
 
-        children = []
-        for children_item_data in self.children:
-            children_item = children_item_data.to_dict()
-            children.append(children_item)
+        children: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.children, Unset):
+            children = []
+            for children_item_data in self.children:
+                children_item = children_item_data.to_dict()
+                children.append(children_item)
 
         uid = self.uid
 
@@ -62,9 +65,10 @@ class SoccerStandingsResponse:
                 "id": id,
                 "name": name,
                 "abbreviation": abbreviation,
-                "children": children,
             }
         )
+        if children is not UNSET:
+            field_dict["children"] = children
         if uid is not UNSET:
             field_dict["uid"] = uid
         if seasons is not UNSET:
@@ -85,8 +89,8 @@ class SoccerStandingsResponse:
         abbreviation = d.pop("abbreviation")
 
         children = []
-        _children = d.pop("children")
-        for children_item_data in _children:
+        _children = d.pop("children", UNSET)
+        for children_item_data in _children or []:
             children_item = SoccerStandingsGroup.from_dict(children_item_data)
 
             children.append(children_item)

--- a/models/site_web_api/espn_site_web_api_client/models/mlb_athlete_details_response.py
+++ b/models/site_web_api/espn_site_web_api_client/models/mlb_athlete_details_response.py
@@ -1,7 +1,9 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.link import Link
@@ -28,8 +30,8 @@ class MLBAthleteDetailsResponse:
         player_switcher (MLBAthleteDetailsResponsePlayerSwitcher):
         quicklinks (List['MLBAthleteDetailsResponseQuicklinksItem']):
         links (List['Link']):
-        tickets_info (MLBAthleteDetailsResponseTicketsInfo):
-        standings (MLBAthleteDetailsResponseStandings):
+        tickets_info (Union[Unset, MLBAthleteDetailsResponseTicketsInfo]):
+        standings (Union[Unset, MLBAthleteDetailsResponseStandings]):
     """
 
     athlete: "MLBAthleteDetailsAthlete"
@@ -38,8 +40,8 @@ class MLBAthleteDetailsResponse:
     player_switcher: "MLBAthleteDetailsResponsePlayerSwitcher"
     quicklinks: List["MLBAthleteDetailsResponseQuicklinksItem"]
     links: List["Link"]
-    tickets_info: "MLBAthleteDetailsResponseTicketsInfo"
-    standings: "MLBAthleteDetailsResponseStandings"
+    tickets_info: Union[Unset, "MLBAthleteDetailsResponseTicketsInfo"] = UNSET
+    standings: Union[Unset, "MLBAthleteDetailsResponseStandings"] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -61,9 +63,13 @@ class MLBAthleteDetailsResponse:
             links_item = links_item_data.to_dict()
             links.append(links_item)
 
-        tickets_info = self.tickets_info.to_dict()
+        tickets_info: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.tickets_info, Unset):
+            tickets_info = self.tickets_info.to_dict()
 
-        standings = self.standings.to_dict()
+        standings: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.standings, Unset):
+            standings = self.standings.to_dict()
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -75,10 +81,12 @@ class MLBAthleteDetailsResponse:
                 "playerSwitcher": player_switcher,
                 "quicklinks": quicklinks,
                 "links": links,
-                "ticketsInfo": tickets_info,
-                "standings": standings,
             }
         )
+        if tickets_info is not UNSET:
+            field_dict["ticketsInfo"] = tickets_info
+        if standings is not UNSET:
+            field_dict["standings"] = standings
 
         return field_dict
 
@@ -116,9 +124,19 @@ class MLBAthleteDetailsResponse:
 
             links.append(links_item)
 
-        tickets_info = MLBAthleteDetailsResponseTicketsInfo.from_dict(d.pop("ticketsInfo"))
+        _tickets_info = d.pop("ticketsInfo", UNSET)
+        tickets_info: Union[Unset, MLBAthleteDetailsResponseTicketsInfo]
+        if isinstance(_tickets_info, Unset):
+            tickets_info = UNSET
+        else:
+            tickets_info = MLBAthleteDetailsResponseTicketsInfo.from_dict(_tickets_info)
 
-        standings = MLBAthleteDetailsResponseStandings.from_dict(d.pop("standings"))
+        _standings = d.pop("standings", UNSET)
+        standings: Union[Unset, MLBAthleteDetailsResponseStandings]
+        if isinstance(_standings, Unset):
+            standings = UNSET
+        else:
+            standings = MLBAthleteDetailsResponseStandings.from_dict(_standings)
 
         mlb_athlete_details_response = cls(
             athlete=athlete,

--- a/tests/test_gambit_tournament_challenge.py
+++ b/tests/test_gambit_tournament_challenge.py
@@ -40,7 +40,12 @@ def test_get_mens_tournament_challenge_details(
     result = response.parsed
     assert isinstance(result, ChallengeResponse)
     assert result.key.startswith("tournament-challenge-bracket-")
-    assert result.active is True
+    # `active` tracks whether the bracket is currently open for play, which is only
+    # true during the tournament window. Outside of it the challenge reports
+    # active=False with state COMPLETE (or PENDING before the next bracket opens),
+    # so assert on the value being a well-formed flag/state rather than a fixed value.
+    assert isinstance(result.active, bool)
+    assert result.state in {"ACTIVE", "PENDING", "COMPLETE"}
     assert result["gameType"] == "BRACKET"
 
     mappings = result["mappings"]

--- a/tests/test_soccer_standings.py
+++ b/tests/test_soccer_standings.py
@@ -25,10 +25,19 @@ def validate_soccer_standings_response(data: SoccerStandingsResponse) -> None:
     assert data.id, "Missing id in response"
     assert data.name, "Missing name in response"
     assert data.abbreviation, "Missing abbreviation in response"
-    assert data.children, "Missing children in response"
-    
+
     logger.info(f"League: {data.name} ({data.abbreviation})")
-    
+
+    # Standings groups ("children") are only populated once a season is under way.
+    # Between seasons the API returns the league metadata without any children, so
+    # treat an empty/unset children list as a valid (off-season) response.
+    if not data.children or data.children is UNSET:
+        logger.info(
+            f"No standings groups for {data.name} (likely off-season); "
+            "skipping detailed standings validation"
+        )
+        return
+
     # Check children (standings groups)
     assert len(data.children) > 0, "Expected at least one standings group"
     logger.info(f"Found {len(data.children)} standings groups")
@@ -63,8 +72,8 @@ def format_soccer_standings(data: SoccerStandingsResponse) -> str:
     """Format soccer standings for display."""
     output = []
     output.append(f"=== {data.name} Standings ===")
-    
-    for group in data.children:
+
+    for group in data.children or []:
         if group.standings and group.standings.entries:
             output.append(f"\n{group.name}")
             output.append("Pos  Team                     P   W   D   L   GF  GA  GD  Pts")


### PR DESCRIPTION
## Summary

Ran the full e2e suite against the live ESPN APIs and found 16 failures caused by the APIs drifting from the generated client models (plus one time-dependent assertion). This PR adapts the affected models and tests so they're green again and more resilient to this kind of drift.

## Changes

- **`news_contributor`**: make `links` optional. Some contributors (e.g. "NFL Nation") now come back without a `links` object, which was throwing `KeyError: 'links'` across every league-news endpoint.
- **`news_category_type`**: add the new `series` category type returned for team-specific news (`ValueError: 'series' is not a valid NewsCategoryType`).
- **`soccer_standings_response`**: make `children` optional and have the soccer-standings test tolerate an off-season league (e.g. Ligue 1) that returns only league metadata with no standings groups. Detailed standings validation is skipped in that case.
- **`mlb_athlete_details_response`**: make `ticketsInfo` and `standings` optional — the MLB athlete profile endpoint no longer returns either.
- **gambit tournament challenge test**: the 2026 men's bracket is now `COMPLETE`, so `active` is `False`. Assert that `active` is a well-formed boolean and `state` is a known value instead of hard-coding `active is True`.

## Testing

`uv run pytest` → **621 passed, 12 skipped, 7 xfailed, 3 xpassed** (was 16 failed before these changes).

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/aaronweldy/espn-openapi/task_i4iunibjga4kbpfb)