### PR TITLE
Update e2e tests for ESPN API behavior changes

### DIFF
--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -25,9 +25,9 @@ logger = logging.getLogger(__name__)
     [
         (SportEnum.FOOTBALL, LeagueEnum.NFL, "401547602", ["gameProjection", "matchupQuality", "teamDefEff", "teamOffEff"]),
         (SportEnum.BASKETBALL, LeagueEnum.NBA, "401584793", ["gameProjection", "matchupQuality", "teamPredPtDiff"]),
-        pytest.param(SportEnum.BASEBALL, LeagueEnum.MLB, "401472463", ["gameProjection"], marks=pytest.mark.xfail(reason="MLB predictor might not be available")),
+        (SportEnum.BASEBALL, LeagueEnum.MLB, "401472463", ["gameProjection"]),
         pytest.param(SportEnum.HOCKEY, LeagueEnum.NHL, "401559593", ["gameProjection"], marks=pytest.mark.xfail(reason="NHL predictor not supported")),
-        pytest.param(SportEnum.FOOTBALL, LeagueEnum.COLLEGE_FOOTBALL, "401628444", ["gameProjection"], marks=pytest.mark.xfail(reason="College football predictor not supported")),
+        (SportEnum.FOOTBALL, LeagueEnum.COLLEGE_FOOTBALL, "401628444", ["gameProjection"]),
     ],
 )
 def test_get_game_predictor(sports_core_api_client, ensure_json_output_dir, sport, league, event_id, expected_stats):

--- a/tests/test_team_ats_records.py
+++ b/tests/test_team_ats_records.py
@@ -22,10 +22,8 @@ logger = logging.getLogger(__name__)
     [
         (SportEnum.FOOTBALL, LeagueEnum.NFL, 2023, 2, "12"),  # Kansas City Chiefs
         (SportEnum.BASKETBALL, LeagueEnum.NBA, 2023, 2, "13"),  # LA Lakers
-        pytest.param(
-            SportEnum.BASEBALL, LeagueEnum.MLB, 2023, 2, "15",  # NY Yankees
-            marks=pytest.mark.xfail(reason="MLB doesn't support ATS - uses run line betting instead")
-        ),
+        # MLB returns a valid (empty) ATS payload rather than erroring
+        (SportEnum.BASEBALL, LeagueEnum.MLB, 2023, 2, "15"),  # NY Yankees
         pytest.param(
             SportEnum.HOCKEY, LeagueEnum.NHL, 2023, 2, "10",  # Toronto Maple Leafs
             marks=pytest.mark.xfail(reason="NHL doesn't support ATS - uses puck line betting instead")


### PR DESCRIPTION
## Summary

Ran the full end-to-end test suite against the live ESPN APIs and updated tests where the API's behavior has changed since they were written.

## What changed

Three parametrized cases were marked `xfail` but now consistently **XPASS** — the underlying endpoints have started returning valid responses. The stale markers are removed so the suite actually asserts the live shape:

- **MLB game predictor** (`test_predictor.py`) — now returns `200` with full predictor data (`gameProjection`, team references, etc.).
- **College Football game predictor** (`test_predictor.py`) — same; now returns valid predictor data.
- **MLB ATS records** (`test_team_ats_records.py`) — returns a valid (empty) `200` payload rather than erroring.

## What was left alone

- **NHL predictor** still returns `400` ("Predictor is not supported for sport: hockey") and **NHL ATS** still returns `500` — their `xfail` markers are kept.
- The 3 initial test failures during the run were all transient `504 Gateway Timeout`s ("timeout waiting for core endpoint") from ESPN, not schema changes — they pass on retry and required no code changes.

## Verification

Full suite is green: `625 passed, 11 skipped, 7 xfailed, 0 xpassed, 0 failed`.

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/aaronweldy/espn-openapi/task_n73chcq9m2oawi20)