### PR TITLE
Update e2e tests to reflect new ESPN API support (MLB/CFB predictor, MLB ATS)

### DIFF
--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -25,9 +25,9 @@ logger = logging.getLogger(__name__)
     [
         (SportEnum.FOOTBALL, LeagueEnum.NFL, "401547602", ["gameProjection", "matchupQuality", "teamDefEff", "teamOffEff"]),
         (SportEnum.BASKETBALL, LeagueEnum.NBA, "401584793", ["gameProjection", "matchupQuality", "teamPredPtDiff"]),
-        pytest.param(SportEnum.BASEBALL, LeagueEnum.MLB, "401472463", ["gameProjection"], marks=pytest.mark.xfail(reason="MLB predictor might not be available")),
+        (SportEnum.BASEBALL, LeagueEnum.MLB, "401472463", ["gameProjection"]),
         pytest.param(SportEnum.HOCKEY, LeagueEnum.NHL, "401559593", ["gameProjection"], marks=pytest.mark.xfail(reason="NHL predictor not supported")),
-        pytest.param(SportEnum.FOOTBALL, LeagueEnum.COLLEGE_FOOTBALL, "401628444", ["gameProjection"], marks=pytest.mark.xfail(reason="College football predictor not supported")),
+        (SportEnum.FOOTBALL, LeagueEnum.COLLEGE_FOOTBALL, "401628444", ["gameProjection"]),
     ],
 )
 def test_get_game_predictor(sports_core_api_client, ensure_json_output_dir, sport, league, event_id, expected_stats):

--- a/tests/test_team_ats_records.py
+++ b/tests/test_team_ats_records.py
@@ -22,10 +22,7 @@ logger = logging.getLogger(__name__)
     [
         (SportEnum.FOOTBALL, LeagueEnum.NFL, 2023, 2, "12"),  # Kansas City Chiefs
         (SportEnum.BASKETBALL, LeagueEnum.NBA, 2023, 2, "13"),  # LA Lakers
-        pytest.param(
-            SportEnum.BASEBALL, LeagueEnum.MLB, 2023, 2, "15",  # NY Yankees
-            marks=pytest.mark.xfail(reason="MLB doesn't support ATS - uses run line betting instead")
-        ),
+        (SportEnum.BASEBALL, LeagueEnum.MLB, 2023, 2, "15"),  # NY Yankees - returns empty 200 payload
         pytest.param(
             SportEnum.HOCKEY, LeagueEnum.NHL, 2023, 2, "10",  # Toronto Maple Leafs
             marks=pytest.mark.xfail(reason="NHL doesn't support ATS - uses puck line betting instead")


### PR DESCRIPTION
## Summary

Running the full e2e suite against the live ESPN API surfaced 3 `XPASS` cases — tests marked `xfail` that now pass because the API's behavior changed. This updates them to reflect the new shape/behavior.

### What changed in the API
- **MLB game predictor** (`/predictor`) now returns valid data (`gameProjection`, win probability, pitching/batting/park adjustments) — previously assumed unavailable.
- **College football game predictor** now returns valid predictor data — previously assumed unsupported.
- **MLB ATS records** (`/ats`) now returns a valid `200` with an empty payload — previously assumed to error out.

### Test changes
- `tests/test_predictor.py`: removed `xfail` from the MLB and college-football parametrized cases.
- `tests/test_team_ats_records.py`: removed `xfail` from the MLB case.

NHL predictor and ATS still return `500`/unsupported, so those cases remain `xfail`.

## Verification
Full suite: **624 passed, 12 skipped, 7 xfailed, 0 xpassed** against the live API.

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/aaronweldy/espn-openapi/task_ot2apcoj884fwxcs)